### PR TITLE
Update calico to 3.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ resources in these repositories are going to be deployed in `kube-system`
 namespace in your Kubernetes cluster.
 
 - [calico](katalog/calico): Calico for Kubernetes. Calico enables networking and
-network policy in Kubernetes clusters across the cloud. Version: **3.6.1**
+network policy in Kubernetes clusters across the cloud. Version: **3.12.0**
 
 You can click on each package to see its documentation.
 
@@ -18,6 +18,7 @@ You can click on each package to see its documentation.
 | v1.0.0                              |      :warning:     |      :warning:     |      :warning:     |
 | v1.0.1                              |      :warning:     |      :warning:     |      :warning:     |
 | v1.1.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v1.2.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 - :white_check_mark: Compatible
 - :warning: Has issues

--- a/docs/releases/v1.2.0.md
+++ b/docs/releases/v1.2.0.md
@@ -1,0 +1,18 @@
+# Release notes
+
+## Changelog
+
+Changes between `1.1.0` and this release: `1.2.0`
+
+- Updated `calico` package from [3.6.1](https://docs.projectcalico.org/v3.6/release-notes/) to
+  [3.12.0](https://docs.projectcalico.org/v3.12/release-notes/).
+  - Added `bandwidth` capability to cni configuration.
+  - Added `priorityClassName: system-cluster-critical` to every calico pod.
+
+## Update procedure
+
+To update calico deployment just apply new kustomize project to the cluster.
+
+```bash
+$ kustomize build katalog/calico | kubectl apply -f -
+```

--- a/katalog/calico/config.yml
+++ b/katalog/calico/config.yml
@@ -10,7 +10,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.0",
+      "cniVersion": "0.3.1",
       "plugins": [
         {
           "type": "calico",
@@ -32,6 +32,10 @@ data:
           "type": "portmap",
           "snat": true,
           "capabilities": {"portMappings": true}
+        },
+        {
+          "type": "bandwidth",
+          "capabilities": {"bandwidth": true}
         }
       ]
     }

--- a/katalog/calico/crd.yml
+++ b/katalog/calico/crd.yml
@@ -1,7 +1,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-   name: felixconfigurations.crd.projectcalico.org
+  name: felixconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -166,3 +166,16 @@ spec:
     kind: NetworkPolicy
     plural: networkpolicies
     singular: networkpolicy
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networksets.crd.projectcalico.org
+spec:
+  scope: Namespaced
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: NetworkSet
+    plural: networksets
+    singular: networkset

--- a/katalog/calico/deploy.yml
+++ b/katalog/calico/deploy.yml
@@ -13,22 +13,24 @@ spec:
       k8s-app: calico-kube-controllers
   template:
     metadata:
+      name: calico-kube-controllers
       labels:
         k8s-app: calico-kube-controllers
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       serviceAccountName: calico-kube-controllers
+      priorityClassName: system-cluster-critical
       containers:
       - name: calico-kube-controllers
-        image: calico/kube-controllers:v3.6.1
+        image: calico/kube-controllers:v3.12.0
         env:
         - name: ENABLED_CONTROLLERS
           value: node

--- a/katalog/calico/ds.yml
+++ b/katalog/calico/ds.yml
@@ -8,6 +8,10 @@ spec:
   selector:
     matchLabels:
       k8s-app: calico-node
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       labels:
@@ -16,7 +20,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
       - effect: NoSchedule
@@ -27,11 +31,32 @@ spec:
         operator: Exists
       serviceAccountName: calico-node
       terminationGracePeriodSeconds: 0
+      priorityClassName: system-node-critical
       initContainers:
-        - name: install-cni
-          image: calico/cni:v3.6.1
-          command: ["/install-cni.sh"]
-          env:
+      - name: upgrade-ipam
+        image: calico/cni:v3.12.0
+        command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
+        env:
+          - name: KUBERNETES_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: CALICO_NETWORKING_BACKEND
+            valueFrom:
+              configMapKeyRef:
+                name: calico-config
+                key: calico_backend
+        volumeMounts:
+          - mountPath: /var/lib/cni/networks
+            name: host-local-net-dir
+          - mountPath: /host/opt/cni/bin
+            name: cni-bin-dir
+        securityContext:
+          privileged: true
+      - name: install-cni
+        image: calico/cni:v3.12.0
+        command: ["/install-cni.sh"]
+        env:
           - name: CNI_CONF_NAME
             value: "10-calico.conflist"
           - name: CNI_NETWORK_CONFIG
@@ -50,14 +75,23 @@ spec:
                 key: veth_mtu
           - name: SLEEP
             value: "false"
-          volumeMounts:
+        volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
           - mountPath: /host/etc/cni/net.d
             name: cni-net-dir
+        securityContext:
+          privileged: true
+      - name: flexvol-driver
+        image: calico/pod2daemon-flexvol:v3.12.0
+        volumeMounts:
+        - name: flexvol-driver-host
+          mountPath: /host/driver
+        securityContext:
+          privileged: true
       containers:
         - name: calico-node
-          image: calico/node:v3.6.1
+          image: calico/node:v3.12.0
           env:
           - name: DATASTORE_TYPE
             value: "kubernetes"
@@ -101,10 +135,11 @@ spec:
             requests:
               cpu: 250m
           livenessProbe:
-            httpGet:
-              path: /liveness
-              port: 9099
-              host: localhost
+            exec:
+              command:
+              - /bin/calico-node
+              - -felix-live
+              - -bird-live
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6
@@ -128,6 +163,8 @@ spec:
           - mountPath: /var/lib/calico
             name: var-lib-calico
             readOnly: false
+          - name: policysync
+            mountPath: /var/run/nodeagent
       volumes:
       - name: lib-modules
         hostPath:
@@ -148,3 +185,14 @@ spec:
       - name: cni-net-dir
         hostPath:
           path: /etc/cni/net.d
+      - name: host-local-net-dir
+        hostPath:
+          path: /var/lib/cni/networks
+      - name: policysync
+        hostPath:
+          type: DirectoryOrCreate
+          path: /var/run/nodeagent
+      - name: flexvol-driver-host
+        hostPath:
+          type: DirectoryOrCreate
+          path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds

--- a/katalog/calico/rbac.yml
+++ b/katalog/calico/rbac.yml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: calico-kube-controllers
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: calico-kube-controllers
@@ -44,7 +44,7 @@ rules:
   - create
   - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: calico-kube-controllers
@@ -55,14 +55,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: calico-kube-controllers
-  namespace: kube-system
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: calico-node
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: calico-node
@@ -119,8 +118,10 @@ rules:
   - globalnetworkpolicies
   - globalnetworksets
   - networkpolicies
+  - networksets
   - clusterinformations
   - hostendpoints
+  - blockaffinities
   verbs:
   - get
   - list
@@ -140,8 +141,6 @@ rules:
   - get
   - list
   - watch
-# These permissions are only requried for upgrade from v2.6, and can
-# be removed after upgrade or on fresh installations.
 - apiGroups: ["crd.projectcalico.org"]
   resources:
   - bgpconfigurations
@@ -170,15 +169,13 @@ rules:
   - blockaffinities
   verbs:
   - watch
-# The Calico IPAM migration needs to get daemonsets. These permissions can be
-# removed if not upgrading from an installation using host-local IPAM.
 - apiGroups: ["apps"]
   resources:
   - daemonsets
   verbs:
   - get
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: calico-node
@@ -189,4 +186,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: calico-node
-  namespace: kube-system


### PR DESCRIPTION
This PR updates calico from 3.6.1 to 3.12.0. 

There is no breaking changes during the upgrade and the update is super straight forward. Just apply the new version.

- Update procedure was tested locally.
- New installation passed in the e2e pipeline: http://ci.sighup.io/sighupio/fury-kubernetes-networking/20

Internal trello card: https://trello.com/c/2b5enaYy

Thanks!