### PR TITLE
Enable calico metrics

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ platform:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0-rc4
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.1
     pull: always
     volumes:
     - name: shared
@@ -51,7 +51,7 @@ steps:
           - refs/tags/**
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0-rc4
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.1
     pull: always
     depends_on: [ test ]
     settings:
@@ -84,7 +84,7 @@ platform:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0-rc4
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.1
     pull: always
     volumes:
     - name: shared
@@ -127,7 +127,7 @@ steps:
           - refs/tags/**
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0-rc4
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.1
     pull: always
     depends_on: [ test ]
     settings:
@@ -160,7 +160,7 @@ platform:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0-rc4
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.1
     pull: always
     volumes:
     - name: shared
@@ -203,7 +203,7 @@ steps:
           - refs/tags/**
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0-rc4
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.1
     pull: always
     depends_on: [ test ]
     settings:

--- a/docs/releases/v1.2.1.md
+++ b/docs/releases/v1.2.1.md
@@ -1,0 +1,15 @@
+# Release notes
+
+## Changelog
+
+Changes between `1.2.0` and this release: `1.2.1`
+
+- Expose calico metrics
+
+## Update procedure
+
+To update calico deployment just apply new kustomize project to the cluster.
+
+```bash
+$ kustomize build katalog/calico | kubectl apply -f -
+```

--- a/katalog/calico/README.md
+++ b/katalog/calico/README.md
@@ -23,6 +23,7 @@ OpenStack, and bare metal services.
 
 - Tested with Kubernetes >= `1.14.X`.
 - Tested with Kustomize = `v3.3.X`.
+- Prometheus Operator.
 
 ## Configuration
 
@@ -32,6 +33,7 @@ Fury distribution calico package is deployed with the following configuration:
 - BGP `(bird)` mode configured instead of `vxlan`.
 - [`kubernetes` datastore](https://docs.projectcalico.org/getting-started/kubernetes/hardway/the-calico-datastore#using-kubernetes-as-the-datastore).
 - Enable support for [traffic shaping](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#support-traffic-shaping).
+- ServiceMonitor *(Prometheus Operator)* configured to scrape metrics every 15 seconds.
 
 ## Deployment
 

--- a/katalog/calico/ds.yml
+++ b/katalog/calico/ds.yml
@@ -112,6 +112,8 @@ spec:
             value: "autodetect"
           - name: CALICO_IPV4POOL_IPIP
             value: "Always"
+          - name: FELIX_PROMETHEUSMETRICSENABLED
+            value: "true"
           - name: FELIX_IPINIPMTU
             valueFrom:
               configMapKeyRef:
@@ -129,6 +131,10 @@ spec:
             value: "info"
           - name: FELIX_HEALTHENABLED
             value: "true"
+          ports:
+            - name: metrics
+              protocol: TCP
+              containerPort: 9091
           securityContext:
             privileged: true
           resources:

--- a/katalog/calico/kustomization.yaml
+++ b/katalog/calico/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 - deploy.yml
 - ds.yml
 - rbac.yml
+- sm.yml

--- a/katalog/calico/sm.yml
+++ b/katalog/calico/sm.yml
@@ -4,12 +4,11 @@ metadata:
   labels:
     k8s-app: calico-node
   name: calico-node
-  namespace: monitoring
 spec:
   endpoints:
   - interval: 15s
     port: metrics
-  jobLabel: calico-node
+  jobLabel: k8s-app
   namespaceSelector:
     matchNames:
     - kube-system

--- a/katalog/calico/sm.yml
+++ b/katalog/calico/sm.yml
@@ -1,0 +1,32 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: calico-node
+  name: calico-node
+  namespace: monitoring
+spec:
+  endpoints:
+  - interval: 15s
+    port: metrics
+  jobLabel: calico-node
+  namespaceSelector:
+    matchNames:
+    - kube-system
+  selector:
+    matchLabels:
+      k8s-app: calico-node
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: calico-node
+  labels:
+    k8s-app: calico-node
+spec:
+  ports:
+  - name: metrics
+    port: 9091
+    protocol: TCP
+  selector:
+    k8s-app: calico-node

--- a/katalog/tests/calico/calico.sh
+++ b/katalog/tests/calico/calico.sh
@@ -40,6 +40,16 @@ load ./../helper
     [ "$status" -eq 0 ]
 }
 
+@test "Calico is exposing metrics" {
+    info
+    test() {
+        kubectl run test-metrics --image=curlimages/curl --restart=OnFailure --command -- curl -q http://calico-node.kube-system.svc.cluster.local:9091/metrics
+        kubectl wait --for=condition=complete  job/test-metrics --timeout=60s
+    }
+    run test
+    [ "$status" -eq 0 ]
+}
+
 @test "Nodes in ready State" {
     info
     test() {

--- a/katalog/tests/calico/calico.sh
+++ b/katalog/tests/calico/calico.sh
@@ -44,8 +44,8 @@ load ./../helper
 @test "Calico is exposing metrics" {
     info
     test() {
-        kubectl run test-metrics --image=curlimages/curl --restart=OnFailure --command -- curl -q http://calico-node.kube-system.svc.cluster.local:9091/metrics
-        kubectl wait --for=condition=complete  job/test-metrics --timeout=60s
+        kubectl run test-metrics --image=curlimages/curl --restart=OnFailure --command -- curl -q -f -m 10 http://calico-node.kube-system.svc.cluster.local:9091/metrics
+        kubectl wait --for=condition=complete job/test-metrics --timeout=15s
     }
     run test
     [ "$status" -eq 0 ]

--- a/katalog/tests/calico/calico.sh
+++ b/katalog/tests/calico/calico.sh
@@ -14,6 +14,7 @@ load ./../helper
 @test "Install Calico" {
     info
     install() {
+        kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v1.6.0/katalog/prometheus-operator/crd-servicemonitor.yml
         apply katalog/calico
     }
     run install


### PR DESCRIPTION
Hi!

This PR is part of a bigger task: `Replace Networking Dashboard` as we moved from weave to calico.

Before exposing a new dashboard, we have to provide metrics. This PR cover it.
I've added a test to ensure we are exposing metrics. Pipeline is passing: http://ci.sighup.io/sighupio/fury-kubernetes-networking/47/1/3

Trello card: https://trello.com/c/4C1uxp2m

Thanks!