### PR TITLE
Change default FELIX_LOGSEVERITYSCREEN from info to error

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,8 @@
+# Release notes
+
+## Changelog
+
+Changes between `1.2.1` and this release: `1.Y.Z`
+
+- Lowered log verbosity from `info` to `error`
+

--- a/katalog/calico/ds.yml
+++ b/katalog/calico/ds.yml
@@ -128,7 +128,7 @@ spec:
           - name: FELIX_IPV6SUPPORT
             value: "false"
           - name: FELIX_LOGSEVERITYSCREEN
-            value: "info"
+            value: "error"
           - name: FELIX_HEALTHENABLED
             value: "true"
           ports:


### PR DESCRIPTION
Hi guys, minor change on networking side.

Calico is logging A LOT non useful stuff, causing pressure on the logging side.

I changed FELIX_LOGSEVERITYSCREEN from info to error