### PR TITLE
Adding support to Kubernetes 1.16, 1.17 and 1.18

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -32,6 +32,7 @@ steps:
       ref:
         include:
           - refs/heads/hotfix-*
+          - refs/heads/feature/rc-v2
           - refs/tags/**
 
   - name: test
@@ -48,6 +49,7 @@ steps:
       ref:
         include:
           - refs/heads/hotfix-*
+          - refs/heads/feature/rc-v2
           - refs/tags/**
 
   - name: destroy
@@ -108,6 +110,7 @@ steps:
       ref:
         include:
           - refs/heads/hotfix-*
+          - refs/heads/feature/rc-v2
           - refs/tags/**
 
   - name: test
@@ -124,6 +127,7 @@ steps:
       ref:
         include:
           - refs/heads/hotfix-*
+          - refs/heads/feature/rc-v2
           - refs/tags/**
 
   - name: destroy
@@ -184,6 +188,7 @@ steps:
       ref:
         include:
           - refs/heads/hotfix-*
+          - refs/heads/feature/rc-v2
           - refs/tags/**
 
   - name: test
@@ -200,6 +205,7 @@ steps:
       ref:
         include:
           - refs/heads/hotfix-*
+          - refs/heads/feature/rc-v2
           - refs/tags/**
 
   - name: destroy

--- a/.drone.yml
+++ b/.drone.yml
@@ -37,8 +37,6 @@ steps:
     when:
       ref:
         include:
-          - refs/heads/hotfix-*
-          - refs/heads/feature/rc-v2
           - refs/tags/**
 
   - name: test
@@ -54,8 +52,6 @@ steps:
     when:
       ref:
         include:
-          - refs/heads/hotfix-*
-          - refs/heads/feature/rc-v2
           - refs/tags/**
 
   - name: destroy
@@ -127,8 +123,6 @@ steps:
     when:
       ref:
         include:
-          - refs/heads/hotfix-*
-          - refs/heads/feature/rc-v2
           - refs/tags/**
 
   - name: test
@@ -144,8 +138,6 @@ steps:
     when:
       ref:
         include:
-          - refs/heads/hotfix-*
-          - refs/heads/feature/rc-v2
           - refs/tags/**
 
   - name: destroy
@@ -217,8 +209,6 @@ steps:
     when:
       ref:
         include:
-          - refs/heads/hotfix-*
-          - refs/heads/feature/rc-v2
           - refs/tags/**
 
   - name: test
@@ -234,8 +224,6 @@ steps:
     when:
       ref:
         include:
-          - refs/heads/hotfix-*
-          - refs/heads/feature/rc-v2
           - refs/tags/**
 
   - name: destroy

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ platform:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.3.3-final-aws
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2
     pull: always
     volumes:
     - name: shared
@@ -59,7 +59,7 @@ steps:
           - refs/tags/**
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.3.3-final-aws
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2
     pull: always
     depends_on: [ test ]
     settings:
@@ -98,7 +98,7 @@ platform:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.3.3-final-aws
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2
     pull: always
     volumes:
     - name: shared
@@ -149,7 +149,7 @@ steps:
           - refs/tags/**
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.3.3-final-aws
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2
     pull: always
     depends_on: [ test ]
     settings:
@@ -188,7 +188,7 @@ platform:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.3.3-final-aws
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2
     pull: always
     volumes:
     - name: shared
@@ -239,7 +239,7 @@ steps:
           - refs/tags/**
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.3.3-final-aws
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2
     pull: always
     depends_on: [ test ]
     settings:

--- a/.drone.yml
+++ b/.drone.yml
@@ -35,7 +35,7 @@ steps:
           - refs/tags/**
 
   - name: test
-    image: quay.io/sighup/e2e-testing:1.1.0_0.1.3_2.16.1_1.4.0_1.16.3_3.2.2_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.16.4_3.2.2_2.4.1
     pull: always
     volumes:
     - name: shared

--- a/.drone.yml
+++ b/.drone.yml
@@ -188,7 +188,7 @@ volumes:
 
 # steps:
 #   - name: init
-#     image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2-rc9
+#     image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2-rc10
 #     pull: always
 #     volumes:
 #     - name: shared
@@ -239,7 +239,7 @@ volumes:
 #           - refs/tags/**
 
 #   - name: destroy
-#     image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2-rc9
+#     image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2-rc10
 #     pull: always
 #     depends_on: [ test ]
 #     settings:

--- a/.drone.yml
+++ b/.drone.yml
@@ -188,7 +188,7 @@ platform:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2-rc10
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2
     pull: always
     volumes:
     - name: shared
@@ -239,7 +239,7 @@ steps:
           - refs/tags/**
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2-rc10
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2
     pull: always
     depends_on: [ test ]
     settings:

--- a/.drone.yml
+++ b/.drone.yml
@@ -28,6 +28,12 @@ steps:
         from_secret: aws_secret_access_key
       terraform_tf_states_bucket_name:
         from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
     when:
       ref:
         include:
@@ -67,6 +73,12 @@ steps:
         from_secret: aws_secret_access_key
       terraform_tf_states_bucket_name:
         from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
     when:
       status:
       - success
@@ -106,6 +118,12 @@ steps:
         from_secret: aws_secret_access_key
       terraform_tf_states_bucket_name:
         from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
     when:
       ref:
         include:
@@ -145,6 +163,12 @@ steps:
         from_secret: aws_secret_access_key
       terraform_tf_states_bucket_name:
         from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
     when:
       status:
       - success
@@ -184,6 +208,12 @@ steps:
         from_secret: aws_secret_access_key
       terraform_tf_states_bucket_name:
         from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
     when:
       ref:
         include:
@@ -223,6 +253,12 @@ steps:
         from_secret: aws_secret_access_key
       terraform_tf_states_bucket_name:
         from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
     when:
       status:
       - success

--- a/.drone.yml
+++ b/.drone.yml
@@ -108,7 +108,7 @@ steps:
       action: custom-cluster-117
       pipeline_id: cluster-117
       local_kind_config_path: katalog/tests/calico/resources/kind-config
-      cluster_version: '1.15.11'
+      cluster_version: '1.17.5'
       instance_path: /shared
       aws_default_region:
         from_secret: aws_region
@@ -178,92 +178,92 @@ volumes:
 - name: shared
   temp: {}
 
----
-kind: pipeline
-name: e2e-kubernetes-1.18
+# ---
+# kind: pipeline
+# name: e2e-kubernetes-1.18
 
-platform:
-  os: linux
-  arch: amd64
+# platform:
+#   os: linux
+#   arch: amd64
 
-steps:
-  - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ clone ]
-    settings:
-      action: custom-cluster-118
-      pipeline_id: cluster-118
-      local_kind_config_path: katalog/tests/calico/resources/kind-config
-      cluster_version: '1.18.0'
-      instance_path: /shared
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-    when:
-      ref:
-        include:
-          - refs/heads/hotfix-*
-          - refs/heads/feature/rc-v2
-          - refs/tags/**
+# steps:
+#   - name: init
+#     image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2-rc9
+#     pull: always
+#     volumes:
+#     - name: shared
+#       path: /shared
+#     depends_on: [ clone ]
+#     settings:
+#       action: custom-cluster-118
+#       pipeline_id: cluster-118
+#       local_kind_config_path: katalog/tests/calico/resources/kind-config
+#       cluster_version: '1.18.0'
+#       instance_path: /shared
+#       aws_default_region:
+#         from_secret: aws_region
+#       aws_access_key_id:
+#         from_secret: aws_access_key_id
+#       aws_secret_access_key:
+#         from_secret: aws_secret_access_key
+#       terraform_tf_states_bucket_name:
+#         from_secret: terraform_tf_states_bucket_name
+#       vsphere_server:
+#         from_secret: vsphere_server
+#       vsphere_password:
+#         from_secret: vsphere_password
+#       vsphere_user:
+#         from_secret: vsphere_user
+#     when:
+#       ref:
+#         include:
+#           - refs/heads/hotfix-*
+#           - refs/heads/feature/rc-v2
+#           - refs/tags/**
 
-  - name: test
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.18.0_3.2.2_2.4.1
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ init ]
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-118
-      - bats -t katalog/tests/calico/calico.sh
-    when:
-      ref:
-        include:
-          - refs/heads/hotfix-*
-          - refs/heads/feature/rc-v2
-          - refs/tags/**
+#   - name: test
+#     image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.18.0_3.2.2_2.4.1
+#     pull: always
+#     volumes:
+#     - name: shared
+#       path: /shared
+#     depends_on: [ init ]
+#     commands:
+#       - export KUBECONFIG=/shared/kube/kubeconfig-118
+#       - bats -t katalog/tests/calico/calico.sh
+#     when:
+#       ref:
+#         include:
+#           - refs/heads/hotfix-*
+#           - refs/heads/feature/rc-v2
+#           - refs/tags/**
 
-  - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2
-    pull: always
-    depends_on: [ test ]
-    settings:
-      action: destroy
-      pipeline_id: cluster-118
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-    when:
-      status:
-      - success
-      - failure
+#   - name: destroy
+#     image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2-rc9
+#     pull: always
+#     depends_on: [ test ]
+#     settings:
+#       action: destroy
+#       pipeline_id: cluster-118
+#       aws_default_region:
+#         from_secret: aws_region
+#       aws_access_key_id:
+#         from_secret: aws_access_key_id
+#       aws_secret_access_key:
+#         from_secret: aws_secret_access_key
+#       terraform_tf_states_bucket_name:
+#         from_secret: terraform_tf_states_bucket_name
+#       vsphere_server:
+#         from_secret: vsphere_server
+#       vsphere_password:
+#         from_secret: vsphere_password
+#       vsphere_user:
+#         from_secret: vsphere_user
+#     when:
+#       status:
+#       - success
+#       - failure
 
-volumes:
-- name: shared
-  temp: {}
+# volumes:
+# - name: shared
+#   temp: {}

--- a/.drone.yml
+++ b/.drone.yml
@@ -6,6 +6,11 @@ platform:
   os: linux
   arch: amd64
 
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+
 steps:
   - name: init
     image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2
@@ -34,10 +39,6 @@ steps:
         from_secret: vsphere_password
       vsphere_user:
         from_secret: vsphere_user
-    when:
-      ref:
-        include:
-          - refs/tags/**
 
   - name: test
     image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.16.4_3.2.2_2.4.1
@@ -49,10 +50,6 @@ steps:
     commands:
       - export KUBECONFIG=/shared/kube/kubeconfig-116
       - bats -t katalog/tests/calico/calico.sh
-    when:
-      ref:
-        include:
-          - refs/tags/**
 
   - name: destroy
     image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2
@@ -92,6 +89,11 @@ platform:
   os: linux
   arch: amd64
 
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+
 steps:
   - name: init
     image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2
@@ -120,10 +122,6 @@ steps:
         from_secret: vsphere_password
       vsphere_user:
         from_secret: vsphere_user
-    when:
-      ref:
-        include:
-          - refs/tags/**
 
   - name: test
     image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.17.2_3.2.2_2.4.1
@@ -135,10 +133,6 @@ steps:
     commands:
       - export KUBECONFIG=/shared/kube/kubeconfig-117
       - bats -t katalog/tests/calico/calico.sh
-    when:
-      ref:
-        include:
-          - refs/tags/**
 
   - name: destroy
     image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2
@@ -178,6 +172,11 @@ platform:
   os: linux
   arch: amd64
 
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+
 steps:
   - name: init
     image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2
@@ -206,10 +205,6 @@ steps:
         from_secret: vsphere_password
       vsphere_user:
         from_secret: vsphere_user
-    when:
-      ref:
-        include:
-          - refs/tags/**
 
   - name: test
     image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.18.0_3.2.2_2.4.1
@@ -221,10 +216,6 @@ steps:
     commands:
       - export KUBECONFIG=/shared/kube/kubeconfig-118
       - bats -t katalog/tests/calico/calico.sh
-    when:
-      ref:
-        include:
-          - refs/tags/**
 
   - name: destroy
     image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2

--- a/.drone.yml
+++ b/.drone.yml
@@ -178,92 +178,92 @@ volumes:
 - name: shared
   temp: {}
 
-# ---
-# kind: pipeline
-# name: e2e-kubernetes-1.18
+---
+kind: pipeline
+name: e2e-kubernetes-1.18
 
-# platform:
-#   os: linux
-#   arch: amd64
+platform:
+  os: linux
+  arch: amd64
 
-# steps:
-#   - name: init
-#     image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2-rc10
-#     pull: always
-#     volumes:
-#     - name: shared
-#       path: /shared
-#     depends_on: [ clone ]
-#     settings:
-#       action: custom-cluster-118
-#       pipeline_id: cluster-118
-#       local_kind_config_path: katalog/tests/calico/resources/kind-config
-#       cluster_version: '1.18.0'
-#       instance_path: /shared
-#       aws_default_region:
-#         from_secret: aws_region
-#       aws_access_key_id:
-#         from_secret: aws_access_key_id
-#       aws_secret_access_key:
-#         from_secret: aws_secret_access_key
-#       terraform_tf_states_bucket_name:
-#         from_secret: terraform_tf_states_bucket_name
-#       vsphere_server:
-#         from_secret: vsphere_server
-#       vsphere_password:
-#         from_secret: vsphere_password
-#       vsphere_user:
-#         from_secret: vsphere_user
-#     when:
-#       ref:
-#         include:
-#           - refs/heads/hotfix-*
-#           - refs/heads/feature/rc-v2
-#           - refs/tags/**
+steps:
+  - name: init
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2-rc10
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ clone ]
+    settings:
+      action: custom-cluster-118
+      pipeline_id: cluster-118
+      local_kind_config_path: katalog/tests/calico/resources/kind-config
+      cluster_version: '1.18.2'
+      instance_path: /shared
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
+    when:
+      ref:
+        include:
+          - refs/heads/hotfix-*
+          - refs/heads/feature/rc-v2
+          - refs/tags/**
 
-#   - name: test
-#     image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.18.0_3.2.2_2.4.1
-#     pull: always
-#     volumes:
-#     - name: shared
-#       path: /shared
-#     depends_on: [ init ]
-#     commands:
-#       - export KUBECONFIG=/shared/kube/kubeconfig-118
-#       - bats -t katalog/tests/calico/calico.sh
-#     when:
-#       ref:
-#         include:
-#           - refs/heads/hotfix-*
-#           - refs/heads/feature/rc-v2
-#           - refs/tags/**
+  - name: test
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.18.0_3.2.2_2.4.1
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ init ]
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-118
+      - bats -t katalog/tests/calico/calico.sh
+    when:
+      ref:
+        include:
+          - refs/heads/hotfix-*
+          - refs/heads/feature/rc-v2
+          - refs/tags/**
 
-#   - name: destroy
-#     image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2-rc10
-#     pull: always
-#     depends_on: [ test ]
-#     settings:
-#       action: destroy
-#       pipeline_id: cluster-118
-#       aws_default_region:
-#         from_secret: aws_region
-#       aws_access_key_id:
-#         from_secret: aws_access_key_id
-#       aws_secret_access_key:
-#         from_secret: aws_secret_access_key
-#       terraform_tf_states_bucket_name:
-#         from_secret: terraform_tf_states_bucket_name
-#       vsphere_server:
-#         from_secret: vsphere_server
-#       vsphere_password:
-#         from_secret: vsphere_password
-#       vsphere_user:
-#         from_secret: vsphere_user
-#     when:
-#       status:
-#       - success
-#       - failure
+  - name: destroy
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.2-rc10
+    pull: always
+    depends_on: [ test ]
+    settings:
+      action: destroy
+      pipeline_id: cluster-118
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
+    when:
+      status:
+      - success
+      - failure
 
-# volumes:
-# - name: shared
-#   temp: {}
+volumes:
+- name: shared
+  temp: {}

--- a/.drone.yml
+++ b/.drone.yml
@@ -152,7 +152,7 @@ volumes:
 
 ---
 kind: pipeline
-name: e2e-kubernetes-1.14
+name: e2e-kubernetes-1.18
 
 platform:
   os: linux
@@ -167,10 +167,10 @@ steps:
       path: /shared
     depends_on: [ clone ]
     settings:
-      action: custom-cluster-114
-      pipeline_id: cluster-114
+      action: custom-cluster-118
+      pipeline_id: cluster-118
       local_kind_config_path: katalog/tests/calico/resources/kind-config
-      cluster_version: '1.14.10'
+      cluster_version: '1.18.0'
       instance_path: /shared
       aws_default_region:
         from_secret: aws_region
@@ -187,14 +187,14 @@ steps:
           - refs/tags/**
 
   - name: test
-    image: quay.io/sighup/e2e-testing:1.1.0_0.1.3_2.16.1_1.4.0_1.14.9_3.2.2_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.18.0_3.2.2_2.4.1
     pull: always
     volumes:
     - name: shared
       path: /shared
     depends_on: [ init ]
     commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-114
+      - export KUBECONFIG=/shared/kube/kubeconfig-118
       - bats -t katalog/tests/calico/calico.sh
     when:
       ref:
@@ -208,7 +208,7 @@ steps:
     depends_on: [ test ]
     settings:
       action: destroy
-      pipeline_id: cluster-114
+      pipeline_id: cluster-118
       aws_default_region:
         from_secret: aws_region
       aws_access_key_id:

--- a/.drone.yml
+++ b/.drone.yml
@@ -76,7 +76,7 @@ volumes:
 
 ---
 kind: pipeline
-name: e2e-kubernetes-1.15
+name: e2e-kubernetes-1.17
 
 platform:
   os: linux
@@ -91,8 +91,8 @@ steps:
       path: /shared
     depends_on: [ clone ]
     settings:
-      action: custom-cluster-115
-      pipeline_id: cluster-115
+      action: custom-cluster-117
+      pipeline_id: cluster-117
       local_kind_config_path: katalog/tests/calico/resources/kind-config
       cluster_version: '1.15.11'
       instance_path: /shared
@@ -111,14 +111,14 @@ steps:
           - refs/tags/**
 
   - name: test
-    image: quay.io/sighup/e2e-testing:1.1.0_0.1.3_2.16.1_1.4.0_1.15.6_3.2.2_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.17.2_3.2.2_2.4.1
     pull: always
     volumes:
     - name: shared
       path: /shared
     depends_on: [ init ]
     commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-115
+      - export KUBECONFIG=/shared/kube/kubeconfig-117
       - bats -t katalog/tests/calico/calico.sh
     when:
       ref:
@@ -132,7 +132,7 @@ steps:
     depends_on: [ test ]
     settings:
       action: destroy
-      pipeline_id: cluster-115
+      pipeline_id: cluster-117
       aws_default_region:
         from_secret: aws_region
       aws_access_key_id:

--- a/README.md
+++ b/README.md
@@ -13,13 +13,14 @@ You can click on each package to see its documentation.
 
 ## Compatibility
 
-| Module Version / Kubernetes Version | 1.14.X             | 1.15.X             | 1.16.X             |
-|-------------------------------------|:------------------:|:------------------:|:------------------:|
-| v1.0.0                              |      :warning:     |      :warning:     |      :warning:     |
-| v1.0.1                              |      :warning:     |      :warning:     |      :warning:     |
-| v1.1.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| v1.2.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| v1.2.1                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Module Version / Kubernetes Version | 1.14.X             | 1.15.X             | 1.16.X             | 1.17.X             | 1.19.X             |
+|-------------------------------------|:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|
+| v1.0.0                              |      :warning:     |      :warning:     |      :warning:     |                    |                    |
+| v1.0.1                              |      :warning:     |      :warning:     |      :warning:     |                    |                    |
+| v1.1.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |
+| v1.2.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |
+| v1.2.1                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |
+| v1.3.0                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 - :white_check_mark: Compatible
 - :warning: Has issues

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,8 +1,0 @@
-# Release notes
-
-## Changelog
-
-Changes between `1.2.1` and this release: `1.Y.Z`
-
-- Lowered log verbosity from `info` to `error`
-

--- a/docs/releases/v1.3.0.md
+++ b/docs/releases/v1.3.0.md
@@ -1,0 +1,8 @@
+# Release notes
+
+## Changelog
+
+Changes between `1.2.1` and this release: `1.3.0`
+
+- Lowered log verbosity from `info` to `error`
+- Support 1.16, 1.17 and 1.18 Kubernetes Version

--- a/katalog/tests/calico/calico.sh
+++ b/katalog/tests/calico/calico.sh
@@ -44,7 +44,7 @@ load ./../helper
 @test "Calico is exposing metrics" {
     info
     test() {
-        kubectl run test-metrics --image=curlimages/curl --restart=OnFailure --command -- curl -q -f -m 10 http://calico-node.kube-system.svc.cluster.local:9091/metrics
+        kubectl apply -f katalog/tests/calico/resources/test-metrics-job.yaml
         kubectl wait --for=condition=complete job/test-metrics --timeout=15s
     }
     run test

--- a/katalog/tests/calico/resources/test-metrics-job.yaml
+++ b/katalog/tests/calico/resources/test-metrics-job.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    run: test-metrics
+  name: test-metrics
+spec:
+  template:
+    metadata:
+      labels:
+        run: test-metrics
+    spec:
+      containers:
+      - command:
+        - curl
+        - -q
+        - -f
+        - -m
+        - "10"
+        - http://calico-node.kube-system.svc.cluster.local:9091/metrics
+        image: curlimages/curl
+        name: test-metrics
+        resources: {}
+      restartPolicy: OnFailure


### PR DESCRIPTION
Hi team!

We are starting to support Kubernetes 1.16 1.17 and 1.18. (tested in vsphere -> http://ci.sighup.io/sighupio/fury-kubernetes-networking/85/3/1)

This PR also includes Release notes v1.3.0 witch includes an unreleased feature.

We have to decide (maybe later) the versioning. Let's start with 1.3.0 ;)