### PR TITLE
Add ip-masquerade-agent to the networking module

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ namespace in your Kubernetes cluster.
 
 - [calico](katalog/calico): Calico for Kubernetes. Calico enables networking and
 network policy in Kubernetes clusters across the cloud. Version: **3.16.1**
+- [ip-masq](katalog/ip-masq): The `ip-masq-agent` configures iptables rules to MASQUERADE traffic outside link-local
+*(optional, enabled by default)* and additional arbitrary IP ranges. Version: **2.5.0**
 
 You can click on each package to see its documentation.
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,17 @@
+# Networking Core Module version TBD
+
+In this release some changes were added:
+
+## Changelog
+
+- Add [ip-masq package](../../katalog/ip-masq) to the module.
+  - Add [an example](../../examples/configure-ip-masq) to fine configure it.
+
+## Upgrade path
+
+To upgrade this core module from `v1.4.0` to `TBD`, you need to download this new version, then apply the
+`kustomize` project. No further action is required.
+
+```bash
+kustomize build katalog/ip-masq | kubectl apply -f -
+```

--- a/examples/configure-ip-masq/Furyfile.yml
+++ b/examples/configure-ip-masq/Furyfile.yml
@@ -1,0 +1,7 @@
+# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+bases:
+  - name: networking/ip-masq
+    version: ip-masq

--- a/examples/configure-ip-masq/README.md
+++ b/examples/configure-ip-masq/README.md
@@ -1,0 +1,68 @@
+# Configure IP Masq
+
+If you need to specify a different masquerade configuration, take a look at this example.
+In this example, both change the container argument and the configuration file.
+
+The new argument configuration adds a new flag:
+
+```yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ip-masq-agent
+spec:
+  template:
+    spec:
+      containers:
+      - name: ip-masq-agent
+        args:
+            - --masq-chain=IP-MASQ
+            - --nomasq-all-reserved-ranges # This one is not shipped by default
+```
+
+Adding the following section to your `kustomization.yaml` file:
+
+```yaml
+patchesStrategicMerge:
+  - daemonset-args.yml
+```
+
+Then the configuration in this example looks like:
+
+```yaml
+nonMasqueradeCIDRs:
+  - 10.0.0.0/8
+  - 192.168.1.0/24
+resyncInterval: 60s
+masqLinkLocal: true
+masqLinkLocalIPv6: false
+```
+
+Adding the following section to your `kustomization.yaml` file:
+
+```yaml
+configMapGenerator:
+  - name: ip-masq-agent
+    behavior: merge
+    files:
+      - config=config.yml
+```
+
+
+final `kustomization.yaml` file should looks like:
+
+```yaml
+bases:
+  - vendor/katalog/networking/ip-masq
+
+patchesStrategicMerge:
+  - daemonset-args.yml
+
+configMapGenerator:
+  - name: ip-masq-agent
+    behavior: merge
+    files:
+      - config=config.yml
+```
+
+The rendered manifests contain the new configuration values.

--- a/examples/configure-ip-masq/config.yml
+++ b/examples/configure-ip-masq/config.yml
@@ -1,0 +1,8 @@
+# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+nonMasqueradeCIDRs: []
+resyncInterval: 60s
+masqLinkLocal: false
+masqLinkLocalIPv6: false

--- a/examples/configure-ip-masq/daemonset-args.yml
+++ b/examples/configure-ip-masq/daemonset-args.yml
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ip-masq-agent
+spec:
+  template:
+    spec:
+      containers:
+      - name: ip-masq-agent
+        args:
+            - --masq-chain=IP-MASQ
+            - --nomasq-all-reserved-ranges

--- a/examples/configure-ip-masq/kustomization.yaml
+++ b/examples/configure-ip-masq/kustomization.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+bases:
+  - vendor/katalog/networking/ip-masq
+
+patchesStrategicMerge:
+  - daemonset-args.yml
+
+configMapGenerator:
+  - name: ip-masq-agent
+    behavior: merge
+    files:
+      - config=config.yml

--- a/katalog/ip-masq/README.md
+++ b/katalog/ip-masq/README.md
@@ -23,10 +23,10 @@ This is useful in environments that expect to only receive packets from node IP 
 ## Configuration
 
 Fury distribution ip-masq package is deployed with the following configuration:
-  - `nonMasqueradeCIDRs`: as an empty list.
-  - `resyncInterval`: set to 60 seconds.
-  - `masqLinkLocal`: set to false.
-  - `masqLinkLocalIPv6`: set to false.
+- `nonMasqueradeCIDRs`: as an empty list.
+- `resyncInterval`: set to 60 seconds.
+- `masqLinkLocal`: set to false.
+- `masqLinkLocalIPv6`: set to false.
 
 *Available configuration parameters listed here:*
 [https://github.com/kubernetes-sigs/ip-masq-agent#configuring-the-agent](https://github.com/kubernetes-sigs/ip-masq-agent#configuring-the-agent)

--- a/katalog/ip-masq/README.md
+++ b/katalog/ip-masq/README.md
@@ -1,8 +1,8 @@
 # IP Masq
 
-IP masquerading is a form of network address translation (NAT) used to perform many-to-one IP address translations, 
-which allows multiple clients to access a destination using a single IP address. A cluster uses IP masquerading so 
-that destinations outside of the cluster only receive packets from node IP addresses instead of Pod IP addresses. 
+IP masquerading is a form of network address translation (NAT) used to perform many-to-one IP address translations,
+which allows multiple clients to access a destination using a single IP address. A cluster uses IP masquerading so
+that destinations outside of the cluster only receive packets from node IP addresses instead of Pod IP addresses.
 This is useful in environments that expect to only receive packets from node IP addresses.
 
 *Source: [https://cloud.google.com/kubernetes-engine/docs](https://cloud.google.com/kubernetes-engine/docs/how-to/ip-masquerade-agent#create_manual)*
@@ -36,6 +36,12 @@ the `--nomasq-all-reserved-ranges` flag used to non-masquerade reserved IP range
 
 *Available flags listed here:*
 [https://github.com/kubernetes-sigs/ip-masq-agent#agent-flags](https://github.com/kubernetes-sigs/ip-masq-agent#agent-flags)
+
+### Important note
+
+You should not attempt to run this agent in a cluster where the Kubelet is also configuring a non-masquerade CIDR.
+You can pass --non-masquerade-cidr=0.0.0.0/0 to the Kubelet to nullify its rule, which will prevent the Kubelet from
+interfering with this agent.
 
 ## Deployment
 

--- a/katalog/ip-masq/README.md
+++ b/katalog/ip-masq/README.md
@@ -1,0 +1,50 @@
+# IP Masq
+
+IP masquerading is a form of network address translation (NAT) used to perform many-to-one IP address translations, 
+which allows multiple clients to access a destination using a single IP address. A cluster uses IP masquerading so 
+that destinations outside of the cluster only receive packets from node IP addresses instead of Pod IP addresses. 
+This is useful in environments that expect to only receive packets from node IP addresses.
+
+*Source: [https://cloud.google.com/kubernetes-engine/docs](https://cloud.google.com/kubernetes-engine/docs/how-to/ip-masquerade-agent#create_manual)*
+
+
+## Image repository and tag
+
+- `ip-masq` image:
+  - `gcr.io/google-containers/ip-masq-agent-amd64:v2.5.0`.
+- `ip-masq` repository:
+  - [https://github.com/kubernetes-sigs/ip-masq-agent](https://github.com/kubernetes-sigs/ip-masq-agent).
+
+## Requirements
+
+- Tested with Kubernetes >= `1.16.X`.
+- Tested with Kustomize = `v3.3.X`.
+
+## Configuration
+
+Fury distribution ip-masq package is deployed with the following configuration:
+  - `nonMasqueradeCIDRs`: as an empty list.
+  - `resyncInterval`: set to 60 seconds.
+  - `masqLinkLocal`: set to false.
+  - `masqLinkLocalIPv6`: set to false.
+
+*Available configuration parameters listed here:*
+[https://github.com/kubernetes-sigs/ip-masq-agent#configuring-the-agent](https://github.com/kubernetes-sigs/ip-masq-agent#configuring-the-agent)
+
+Also, the design of this `kustomize` project makes it possible to extend the container arguments adding, as an example
+the `--nomasq-all-reserved-ranges` flag used to non-masquerade reserved IP ranges by default.
+
+*Available flags listed here:*
+[https://github.com/kubernetes-sigs/ip-masq-agent#agent-flags](https://github.com/kubernetes-sigs/ip-masq-agent#agent-flags)
+
+## Deployment
+
+You can deploy `ip-masq` with the default configuration by running the following command in the root of this project:
+
+```shell
+kustomize build | kubectl apply -f -
+```
+
+## License
+
+For license details please see [LICENSE](./../../LICENSE)

--- a/katalog/ip-masq/config.yml
+++ b/katalog/ip-masq/config.yml
@@ -1,0 +1,4 @@
+nonMasqueradeCIDRs: []
+resyncInterval: 60s
+masqLinkLocal: false
+masqLinkLocalIPv6: false

--- a/katalog/ip-masq/config.yml
+++ b/katalog/ip-masq/config.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
 nonMasqueradeCIDRs: []
 resyncInterval: 60s
 masqLinkLocal: false

--- a/katalog/ip-masq/daemonset-args.yml
+++ b/katalog/ip-masq/daemonset-args.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/katalog/ip-masq/daemonset-args.yml
+++ b/katalog/ip-masq/daemonset-args.yml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ip-masq-agent
+spec:
+  template:
+    spec:
+      containers:
+      - name: ip-masq-agent
+        args:
+            - --masq-chain=IP-MASQ
+            # To non-masquerade reserved IP ranges by default, uncomment the line below.
+            # - --nomasq-all-reserved-ranges

--- a/katalog/ip-masq/daemonset.yml
+++ b/katalog/ip-masq/daemonset.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/katalog/ip-masq/daemonset.yml
+++ b/katalog/ip-masq/daemonset.yml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ip-masq-agent
+spec:
+  template:
+    spec:
+      hostNetwork: true
+      containers:
+      - name: ip-masq-agent
+        image: gcr.io/google-containers/ip-masq-agent-amd64
+        args:
+            - --masq-chain=IP-MASQ
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - name: config
+            mountPath: /etc/config
+      volumes:
+        - name: config
+          configMap:
+            # Note this ConfigMap must be created in the same namespace as the
+            # daemon pods - this spec uses kube-system
+            name: ip-masq-agent
+            optional: true
+            items:
+              # The daemon looks for its config in a YAML file at /etc/config/ip-masq-agent
+              - key: config
+                path: ip-masq-agent
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists

--- a/katalog/ip-masq/kustomization.yml
+++ b/katalog/ip-masq/kustomization.yml
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+namespace: kube-system
+
+commonLabels:
+  k8s-app: ip-masq-agent
+
+resources:
+  - daemonset.yml
+
+patchesStrategicMerge:
+  - daemonset-args.yml
+
+images:
+  - name: gcr.io/google-containers/ip-masq-agent-amd64
+    newTag: v2.5.0
+
+configMapGenerator:
+  - name: ip-masq-agent
+    files:
+      - config=config.yml


### PR DESCRIPTION
Hi team!

Both @nutellinoit and @nikever faced the need to masquerade pods IPS from outside the cluster.

This PR aims to fix this gap. It adds an example about how to configure it.

Thanks!