### PR TITLE
Bump version: 1.8.0 → 1.8.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 1.8.0
+current_version = 1.8.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-rc(?P<rc>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-rc{rc}

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 ```yaml
 bases:
   - name: networking/calico
-    version: "v1.8.0"
+    version: "v1.8.1"
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.

--- a/docs/releases/v1.8.0.md
+++ b/docs/releases/v1.8.0.md
@@ -1,7 +1,7 @@
 # Networking Core Module Release 1.8.0
 
-Welcome to the latest release of `Networking` module of (`Kubernetes Fury
-Distribution`)[https://github.com/sighupio/fury-distribution] maintained by team
+Welcome to the latest release of `Networking` module of [`Kubernetes Fury
+Distribution`](https://github.com/sighupio/fury-distribution) maintained by team
 SIGHUP.
 
 This latest release is an attempt on upgrading the components in the module to

--- a/docs/releases/v1.8.1.md
+++ b/docs/releases/v1.8.1.md
@@ -1,7 +1,7 @@
 # Networking Core Module Release 1.8.1
 
-Welcome to the latest release of `Networking` module of (`Kubernetes Fury
-Distribution`)[https://github.com/sighupio/fury-distribution] maintained by team
+Welcome to the latest release of `Networking` module of [`Kubernetes Fury
+Distribution`](https://github.com/sighupio/fury-distribution) maintained by team
 SIGHUP.
 
 This is a patch release with a documentation improvement and structure change.

--- a/katalog/calico/kustomization.yaml
+++ b/katalog/calico/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: kube-system
 
 commonLabels:
   module.kfd.sighup.io/name: "networking"
-  module.kfd.sighup.io/version: "v1.8.0"
+  module.kfd.sighup.io/version: "v1.8.1"
   module.kfd.sighup.io/component: "calico"
   kfd.sighup.io/source: "kustomize"
 

--- a/katalog/ip-masq/kustomization.yml
+++ b/katalog/ip-masq/kustomization.yml
@@ -11,7 +11,7 @@ namespace: kube-system
 commonLabels:
   k8s-app: ip-masq-agent
   module.kfd.sighup.io/name: "networking"
-  module.kfd.sighup.io/version: "v1.8.0"
+  module.kfd.sighup.io/version: "v1.8.1"
   module.kfd.sighup.io/component: "ip-masq"
   kfd.sighup.io/source: "kustomize"
 


### PR DESCRIPTION
I made a mistake and push the release note directly to master [here](https://github.com/sighupio/fury-kubernetes-networking/blob/master/docs/releases/v1.8.1.md). My apologies