### PR TITLE
Fix Tigera Operator image registry

### DIFF
--- a/katalog/tigera/operator/kustomization.yaml
+++ b/katalog/tigera/operator/kustomization.yaml
@@ -9,5 +9,5 @@ resources:
   - tigera-operator.yaml
 
 images:
-  - name: quay.io/tigera/operator:v1.28.1
+  - name: quay.io/tigera/operator
     newName: registry.sighup.io/fury/tigera/operator


### PR DESCRIPTION
Remove the tag from the image patch to download the image of the tigera operator from SIGHUP's registry.

At the current state of the module, the kustomization.yaml file patches only the image `v1.28.1` but the manifest has been updated to use the image `v1.29.0`.