### PR TITLE
fix(tigera): add missing trailing slash to .spec.registry

### DIFF
--- a/docs/releases/v1.12.2.md
+++ b/docs/releases/v1.12.2.md
@@ -1,0 +1,31 @@
+# Networking Core Module Release 1.12.2
+
+Welcome to the latest release of `Networking` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+
+This is a patch release that fixes one issue with tigera eks-policy-only package.
+
+## Component Images 🚢
+
+| Component         | Supported Version                                                                | Previous Version |
+| ----------------- | -------------------------------------------------------------------------------- | ---------------- |
+| `calico`          | [`v3.25.0`](https://projectcalico.docs.tigera.io/archive/v3.25/release-notes/)   | No update        |
+| `ip-masq`         | [`v2.8.0`](https://github.com/kubernetes-sigs/ip-masq-agent/releases/tag/v2.5.0) | No update        |
+| `tigera-operator` | [`v1.29.0`](https://github.com/tigera/operator/releases/tag/v1.29.0)             | No update        |
+
+> Please refer the individual release notes to get detailed information on each release.
+
+## Bug Fixes and Changes 🐛
+
+- [#61](https://github.com/sighupio/fury-kubernetes-networking/pull/61) add trailing slash to tigera operator installation's .spec.registry
+
+## Update Guide 🦮
+
+### Process
+
+If you are upgrading from version `v1.12.1` to `v1.12.2` you need to download this new version and then apply the `kustomize` project as shown below.
+
+```bash
+kustomize build katalog/tigera/eks-policy-only | kubectl apply -f -
+```
+
+If you are upgrading from previous versions, please refer to the [`v1.11.0` release notes](https://github.com/sighupio/fury-kubernetes-networking/releases/tag/v1.11.0).

--- a/katalog/tigera/eks-policy-only/calico-crs.yaml
+++ b/katalog/tigera/eks-policy-only/calico-crs.yaml
@@ -11,7 +11,7 @@ kind: Installation
 metadata:
   name: default
 spec:
-  registry: registry.sighup.io
+  registry: registry.sighup.io/
   imagePath: fury/calico
   # Configures Calico policy configured to work with AmazonVPC CNI networking.
   cni:


### PR DESCRIPTION
Fixing an issue that causes a conflict during application of the manifests at the `.spec.registry` key due to a missing (and required) trailing slash in the registry url.

As per `k explain installation.spec.registry`:

```
KIND:     Installation
VERSION:  operator.tigera.io/v1

FIELD:    registry <string>

DESCRIPTION:
     Registry is the default Docker registry used for component Docker images.
     If specified then the given value must end with a slash character (`/`) and
     all images will be pulled from this registry. If not specified then the
     default registries will be used. A special case value, UseDefault, is
     supported to explicitly specify the default registries will be used. Image
     format: `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>` This
     option allows configuring the `<registry>` portion of the above format.
```