### PR TITLE
Install dashboards in calico-system namespace

### DIFF
--- a/katalog/tigera/on-prem/monitoring/kustomization.yaml
+++ b/katalog/tigera/on-prem/monitoring/kustomization.yaml
@@ -16,6 +16,7 @@ generatorOptions:
 
 configMapGenerator:
   - name: networking-grafana-dashboard
+    namespace: calico-system
     files:
       - dashboards/felix-dashboard.json
       - dashboards/typha-dashboard.json


### PR DESCRIPTION
Currently, the dashboards of the tigera on-prem package get installed inside the `default` namespace.
This PR installs them inside `calico-system` namespace.