### PR TITLE
feat: put dashboards in "Networking" grafana folder

### DIFF
--- a/katalog/calico/monitoring/kustomization.yaml
+++ b/katalog/calico/monitoring/kustomization.yaml
@@ -9,12 +9,14 @@ kind: Kustomization
 namespace: kube-system
 
 resources:
-  - "sm.yml"  # ServiceMonitor defintion
-  - "prometheusrules.yaml"  # ServiceMonitor defintion
+  - "sm.yml" # ServiceMonitor defintion
+  - "prometheusrules.yaml" # ServiceMonitor defintion
 
 generatorOptions:
   labels:
     grafana-sighup-dashboard: default
+  annotations:
+    grafana-folder: "Networking"
   disableNameSuffixHash: true
 
 configMapGenerator:

--- a/katalog/cilium/core/monitoring/kustomization.yaml
+++ b/katalog/cilium/core/monitoring/kustomization.yaml
@@ -11,6 +11,8 @@ namespace: kube-system
 generatorOptions:
   labels:
     grafana-sighup-dashboard: default
+  annotations:
+    grafana-folder: "Networking"
   disableNameSuffixHash: true
 
 configMapGenerator:

--- a/katalog/cilium/hubble/monitoring/kustomization.yaml
+++ b/katalog/cilium/hubble/monitoring/kustomization.yaml
@@ -11,6 +11,8 @@ namespace: kube-system
 generatorOptions:
   labels:
     grafana-sighup-dashboard: default
+  annotations:
+    grafana-folder: "Networking"
   disableNameSuffixHash: true
 
 configMapGenerator:

--- a/katalog/tigera/on-prem/monitoring/kustomization.yaml
+++ b/katalog/tigera/on-prem/monitoring/kustomization.yaml
@@ -12,6 +12,8 @@ resources:
 generatorOptions:
   labels:
     grafana-sighup-dashboard: default
+  annotations:
+    grafana-folder: "Networking"
   disableNameSuffixHash: true
 
 configMapGenerator:


### PR DESCRIPTION
Add annotation to put the module's Grafana dashboards inside the "Networking" folder for better organization.