### PR TITLE
Upgrade calico to v3.27.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Kubernetes Fury Networking provides the following packages:
 
 | Package                    | Version  | Description                                                                                                                                          |
 | -------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [calico](katalog/calico)   | `3.26.3` | [Calico][calico-page] CNI Plugin. For cluster with `< 50` nodes.                                                                                     |
+| [calico](katalog/calico)   | `3.27.0` | [Calico][calico-page] CNI Plugin. For cluster with `< 50` nodes.                                                                                     |
 | [cilium](katalog/cilium)   | `1.14.3` | [Cilium][cilium-page] CNI Plugin. For cluster with `< 200` nodes.                                                                                    |
 | [tigera](katalog/tigera)   | `1.30.7` | [Tigera Operator][tigera-page], a Kubernetes Operator for Calico, provides pre-configured installations for on-prem and for EKS in policy-only mode. |
 | [ip-masq](katalog/ip-masq) | `2.8.0`  | The `ip-masq-agent` configures iptables rules to implement IP masquerading functionality                                                             |

--- a/docs/releases/v1.16.0.md
+++ b/docs/releases/v1.16.0.md
@@ -1,0 +1,64 @@
+# Networking Core Module Release 1.16.0
+
+Welcome to the latest release of the `Networking` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+
+This minor release updates some components and adds support to Kubernetes 1.28.
+
+## Component Images 🚢
+
+| Component         | Supported Version                                                                | Previous Version |
+| ----------------- | -------------------------------------------------------------------------------- | ---------------- |
+| `calico`          | [`v3.26.3`](https://projectcalico.docs.tigera.io/archive/v3.26/release-notes/)   | `v3.26.1`        |
+| `cilium`          | [`v1.14.3`](https://github.com/cilium/cilium/releases/tag/v1.14.3)               | `v1.13.1`        |
+| `ip-masq`         | [`v2.8.0`](https://github.com/kubernetes-sigs/ip-masq-agent/releases/tag/v2.5.0) | No update        |
+| `tigera-operator` | [`v1.30.7`](https://github.com/tigera/operator/releases/tag/v1.30.7)             | `v1.30.4`        |
+
+> Please refer the individual release notes to get detailed information on each release.
+
+## Update Guide 🦮
+
+### Process
+
+If you are using Cilium, read the steps [below](#cilium-upgrade) before proceeding.
+
+1. Just deploy as usual:
+
+```bash
+kustomize build katalog/calico | kubectl apply -f -
+# OR
+kustomize build katalog/tigera/on-prem | kubectl apply -f -
+# OR
+kustomize build katalog/cilium | kubectl apply -f -
+```
+
+#### Cilium upgrade
+Cilium suggested path expect a pre-flight check to be run before any upgrade.
+
+1. Create the resources for the check
+```bash
+kubectl create -f katalog/cilium/tasks/preflight.yaml
+```
+
+2. Make sure that the number of READY pods is the same as the number of RUNNING Cilium pods.
+```text
+kubectl get daemonset -n kube-system | sed -n '1p;/cilium/p'
+NAME                      DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
+cilium                    2         2         2       2            2           <none>          1h20m
+cilium-pre-flight-check   2         2         2       2            2           <none>          7m15s
+```
+
+3. Once the number of READY pods is equal, make sure the Cilium pre-flight deployment is also marked as READY 1/1.
+If it shows READY 0/1, consult the [CNP Validation](https://docs.cilium.io/en/stable/operations/upgrade/#cnp-validation) section in the official docs and resolve issues with the deployment before continuing with the upgrade.
+```text
+kubectl get deployment -n kube-system cilium-pre-flight-check -w
+NAME                      READY   UP-TO-DATE   AVAILABLE   AGE
+cilium-pre-flight-check   1/1     1            0           12s
+```
+
+4. Once the number of READY for the preflight DaemonSet is the same as the number of cilium pods running and the preflight Deployment is marked as READY 1/1 you can delete the cilium-preflight and proceed with the upgrade.
+```bash
+kubectl delete -f cilium-preflight.yaml
+```
+
+
+If you are upgrading from previous versions, please refer to the [`v1.14.0` release notes](https://github.com/sighupio/fury-kubernetes-networking/releases/tag/v1.14.0).

--- a/docs/releases/v1.16.0.md
+++ b/docs/releases/v1.16.0.md
@@ -8,7 +8,7 @@ This minor release updates some components and adds support to Kubernetes 1.28.
 
 | Component         | Supported Version                                                                | Previous Version |
 | ----------------- | -------------------------------------------------------------------------------- | ---------------- |
-| `calico`          | [`v3.26.3`](https://projectcalico.docs.tigera.io/archive/v3.26/release-notes/)   | `v3.26.1`        |
+| `calico`          | [`v3.27.0`](https://docs.tigera.io/calico/3.27/about/)                           | `v3.27.0`        |
 | `cilium`          | [`v1.14.3`](https://github.com/cilium/cilium/releases/tag/v1.14.3)               | `v1.13.1`        |
 | `ip-masq`         | [`v2.8.0`](https://github.com/kubernetes-sigs/ip-masq-agent/releases/tag/v2.5.0) | No update        |
 | `tigera-operator` | [`v1.30.7`](https://github.com/tigera/operator/releases/tag/v1.30.7)             | `v1.30.4`        |

--- a/katalog/calico/MAINTENANCE.md
+++ b/katalog/calico/MAINTENANCE.md
@@ -7,8 +7,8 @@ To update the Calico package with upstream, please follow the next steps:
 1. Download upstream manifests:
 
 ```bash
-export CALICO_VERSION=3.26.1
-curl -L https://raw.githubusercontent.com/projectcalico/calico/v${CALICO_VERSION}/manifests/calico.yaml -o calico-${CALICO_VERSION}.yaml
+export CALICO_VERSION=3.27.0
+curl -L "https://raw.githubusercontent.com/projectcalico/calico/v${CALICO_VERSION}/manifests/calico.yaml" -o calico-${CALICO_VERSION}.yaml
 ```
 
 2. Diff the downloaded manifest with the module's manifests:
@@ -20,7 +20,7 @@ Compare the `deploy.yaml` file with the downloaded `calico-${CALICO_VERSION}` fi
 3. Update the `kustomization.yaml` file with the right image versions.
 
 ```bash
-export CALICO_IMAGE_TAG=v3.26.3
+export CALICO_IMAGE_TAG=v3.27.0
 kustomize edit set image docker.io/calico/kube-controllers=registry.sighup.io/fury/calico/kube-controllers:${CALICO_IMAGE_TAG}
 kustomize edit set image docker.io/calico/cni=registry.sighup.io/fury/calico/cni:${CALICO_IMAGE_TAG}
 kustomize edit set image docker.io/calico/node=registry.sighup.io/fury/calico/node:${CALICO_IMAGE_TAG}
@@ -39,10 +39,10 @@ See <https://docs.tigera.io/calico/latest/operations/monitor/monitor-component-m
 1. Download the dashboard from upstream:
 
 ```bash
-export CALICO_VERSION=3.26.3
+export CALICO_VERSION=3.27.0
 # ⚠️ Assuming $PWD == root of the project
 # We take the `felix-dashboard.json` from the downloaded yaml, we are not deploying `typha`, so we don't need its dashboard.
-curl -L https://raw.githubusercontent.com/projectcalico/calico/v${CALICO_VERSION}/manifests/grafana-dashboards.yaml | yq '.data["felix-dashboard.json"]' | sed 's/calico-demo-prometheus/prometheus/g' | jq > ./monitoring/dashboards/felix-dashboard.json
+curl -L "https://raw.githubusercontent.com/projectcalico/calico/v${CALICO_VERSION}/manifests/grafana-dashboards.yaml" | yq '.data["felix-dashboard.json"]' | sed 's/calico-demo-prometheus/prometheus/g' | jq > ./monitoring/dashboards/felix-dashboard.json
 ```
 
 ### Alerts

--- a/katalog/calico/deploy.yaml
+++ b/katalog/calico/deploy.yaml
@@ -329,12 +329,14 @@ spec:
                       type: string
                     cidr:
                       type: string
+                    interface:
+                      type: string
                     matchOperator:
+                      type: string
+                    source:
                       type: string
                   required:
                   - action
-                  - cidr
-                  - matchOperator
                   type: object
                 type: array
               exportV6:
@@ -348,12 +350,14 @@ spec:
                       type: string
                     cidr:
                       type: string
+                    interface:
+                      type: string
                     matchOperator:
+                      type: string
+                    source:
                       type: string
                   required:
                   - action
-                  - cidr
-                  - matchOperator
                   type: object
                 type: array
               importV4:
@@ -367,12 +371,14 @@ spec:
                       type: string
                     cidr:
                       type: string
+                    interface:
+                      type: string
                     matchOperator:
+                      type: string
+                    source:
                       type: string
                   required:
                   - action
-                  - cidr
-                  - matchOperator
                   type: object
                 type: array
               importV6:
@@ -386,12 +392,14 @@ spec:
                       type: string
                     cidr:
                       type: string
+                    interface:
+                      type: string
                     matchOperator:
+                      type: string
+                    source:
                       type: string
                   required:
                   - action
-                  - cidr
-                  - matchOperator
                   type: object
                 type: array
             type: object
@@ -986,12 +994,32 @@ spec:
                 - Enable
                 - Disable
                 type: string
+              bpfCTLBLogFilter:
+                description: 'BPFCTLBLogFilter specifies, what is logged by connect
+                  time load balancer when BPFLogLevel is debug. Currently has to be
+                  specified as ''all'' when BPFLogFilters is set to see CTLB logs.
+                  [Default: unset - means logs are emitted when BPFLogLevel id debug
+                  and BPFLogFilters not set.]'
+                type: string
+              bpfConnectTimeLoadBalancing:
+                description: 'BPFConnectTimeLoadBalancing when in BPF mode, controls
+                  whether Felix installs the connect-time load balancer. The connect-time
+                  load balancer is required for the host to be able to reach Kubernetes
+                  services and it improves the performance of pod-to-service connections.When
+                  set to TCP, connect time load balancing is available only for services
+                  with TCP ports. [Default: TCP]'
+                enum:
+                - TCP
+                - Enabled
+                - Disabled
+                type: string
               bpfConnectTimeLoadBalancingEnabled:
                 description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
                   controls whether Felix installs the connection-time load balancer.  The
                   connect-time load balancer is required for the host to be able to
                   reach Kubernetes services and it improves the performance of pod-to-service
-                  connections.  The only reason to disable it is for debugging purposes.  [Default:
+                  connections.  The only reason to disable it is for debugging purposes.
+                  This will be deprecated. Use BPFConnectTimeLoadBalancing [Default:
                   true]'
                 type: boolean
               bpfDSROptoutCIDRs:
@@ -1010,6 +1038,12 @@ spec:
                   the cluster.  It should not match the workload interfaces (usually
                   named cali...).
                 type: string
+              bpfDisableGROForIfaces:
+                description: BPFDisableGROForIfaces is a regular expression that controls
+                  which interfaces Felix should disable the Generic Receive Offload
+                  [GRO] option.  It should not match the workload interfaces (usually
+                  named cali...).
+                type: string
               bpfDisableUnprivileged:
                 description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
                   sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
@@ -1025,6 +1059,7 @@ spec:
                   with BPF programs regardless of what is the per-interfaces or global
                   setting. Possible values are Disabled, Strict or Loose. [Default:
                   Loose]'
+                pattern: ^(?i)(Disabled|Strict|Loose)?$
                 type: string
               bpfExtToServiceConnmark:
                 description: 'BPFExtToServiceConnmark in BPF mode, control a 32bit
@@ -1042,12 +1077,31 @@ spec:
                   is sent directly from the remote node.  In "DSR" mode, the remote
                   node appears to use the IP of the ingress node; this requires a
                   permissive L2 network.  [Default: Tunnel]'
+                pattern: ^(?i)(Tunnel|DSR)?$
                 type: string
+              bpfForceTrackPacketsFromIfaces:
+                description: 'BPFForceTrackPacketsFromIfaces in BPF mode, forces traffic
+                  from these interfaces to skip Calico''s iptables NOTRACK rule, allowing
+                  traffic from those interfaces to be tracked by Linux conntrack.  Should
+                  only be used for interfaces that are not used for the Calico fabric.  For
+                  example, a docker bridge device for non-Calico-networked containers.
+                  [Default: docker+]'
+                items:
+                  type: string
+                type: array
               bpfHostConntrackBypass:
                 description: 'BPFHostConntrackBypass Controls whether to bypass Linux
                   conntrack in BPF mode for workloads and services. [Default: true
                   - bypass Linux conntrack]'
                 type: boolean
+              bpfHostNetworkedNATWithoutCTLB:
+                description: 'BPFHostNetworkedNATWithoutCTLB when in BPF mode, controls
+                  whether Felix does a NAT without CTLB. This along with BPFConnectTimeLoadBalancing
+                  determines the CTLB behavior. [Default: Enabled]'
+                enum:
+                - Enabled
+                - Disabled
+                type: string
               bpfKubeProxyEndpointSlicesEnabled:
                 description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
                   whether Felix's embedded kube-proxy accepts EndpointSlices or not.
@@ -1063,6 +1117,7 @@ spec:
                   minimum time between updates to the dataplane for Felix''s embedded
                   kube-proxy.  Lower values give reduced set-up latency.  Higher values
                   reduce Felix CPU usage by batching up more work.  [Default: 1s]'
+                pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                 type: string
               bpfL3IfacePattern:
                 description: BPFL3IfacePattern is a regular expression that allows
@@ -1072,11 +1127,22 @@ spec:
                   as any interfaces that handle incoming traffic to nodeports and
                   services from outside the cluster.
                 type: string
+              bpfLogFilters:
+                additionalProperties:
+                  type: string
+                description: "BPFLogFilters is a map of key=values where the value
+                  is a pcap filter expression and the key is an interface name with
+                  'all' denoting all interfaces, 'weps' all workload endpoints and
+                  'heps' all host endpoints. \n When specified as an env var, it accepts
+                  a comma-separated list of key=values. [Default: unset - means all
+                  debug logs are emitted]"
+                type: object
               bpfLogLevel:
                 description: 'BPFLogLevel controls the log level of the BPF programs
                   when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
                   logs are emitted to the BPF trace pipe, accessible with the command
                   `tc exec bpf debug`. [Default: Off].'
+                pattern: ^(?i)(Off|Info|Debug)?$
                 type: string
               bpfMapSizeConntrack:
                 description: 'BPFMapSizeConntrack sets the size for the conntrack
@@ -1141,6 +1207,7 @@ spec:
                   to append mode, be sure that the other rules in the chains signal
                   acceptance by falling through to the Calico rules, otherwise the
                   Calico policy will be bypassed. [Default: insert]'
+                pattern: ^(?i)(insert|append)?$
                 type: string
               dataplaneDriver:
                 description: DataplaneDriver filename of the external dataplane driver
@@ -1159,8 +1226,10 @@ spec:
               debugMemoryProfilePath:
                 type: string
               debugSimulateCalcGraphHangAfter:
+                pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                 type: string
               debugSimulateDataplaneHangAfter:
+                pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                 type: string
               defaultEndpointToHostAction:
                 description: 'DefaultEndpointToHostAction controls what happens to
@@ -1175,6 +1244,7 @@ spec:
                   endpoint egress policy. Use ACCEPT to unconditionally accept packets
                   from workloads after processing workload endpoint egress policy.
                   [Default: Drop]'
+                pattern: ^(?i)(Drop|Accept|Return)?$
                 type: string
               deviceRouteProtocol:
                 description: This defines the route protocol added to programmed device
@@ -1193,6 +1263,7 @@ spec:
               disableConntrackInvalidCheck:
                 type: boolean
               endpointReportingDelay:
+                pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                 type: string
               endpointReportingEnabled:
                 type: boolean
@@ -1260,12 +1331,14 @@ spec:
                   based on auto-detected platform capabilities.  Values are specified
                   in a comma separated list with no spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".  "true"
                   or "false" will force the feature, empty or omitted values are auto-detected.
+                pattern: ^([a-zA-Z0-9-_]+=(true|false|),)*([a-zA-Z0-9-_]+=(true|false|))?$
                 type: string
               featureGates:
                 description: FeatureGates is used to enable or disable tech-preview
                   Calico features. Values are specified in a comma separated list
                   with no spaces, example; "BPFConnectTimeLoadBalancingWorkaround=enabled,XyZ=false".
                   This is used to enable features that are not fully production ready.
+                pattern: ^([a-zA-Z0-9-_]+=([^=]+),)*([a-zA-Z0-9-_]+=([^=]+))?$
                 type: string
               floatingIPs:
                 description: FloatingIPs configures whether or not Felix will program
@@ -1327,6 +1400,7 @@ spec:
                 description: InterfaceRefreshInterval is the period at which Felix
                   rescans local interfaces to verify their state. The rescan can be
                   disabled by setting the interval to 0.
+                pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                 type: string
               ipipEnabled:
                 description: 'IPIPEnabled overrides whether Felix should configure
@@ -1342,18 +1416,22 @@ spec:
                   all iptables state to ensure that no other process has accidentally
                   broken Calico''s rules. Set to 0 to disable iptables refresh. [Default:
                   90s]'
+                pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                 type: string
               iptablesBackend:
                 description: IptablesBackend specifies which backend of iptables will
                   be used. The default is Auto.
+                pattern: ^(?i)(Auto|FelixConfiguration|FelixConfigurationList|Legacy|NFT)?$
                 type: string
               iptablesFilterAllowAction:
+                pattern: ^(?i)(Accept|Return)?$
                 type: string
               iptablesFilterDenyAction:
                 description: IptablesFilterDenyAction controls what happens to traffic
                   that is denied by network policy. By default Calico blocks traffic
                   with an iptables "DROP" action. If you want to use "REJECT" action
                   instead you can configure it in here.
+                pattern: ^(?i)(Drop|Reject)?$
                 type: string
               iptablesLockFilePath:
                 description: 'IptablesLockFilePath is the location of the iptables
@@ -1366,6 +1444,7 @@ spec:
                   wait between attempts to acquire the iptables lock if it is not
                   available. Lower values make Felix more responsive when the lock
                   is contended, but use more CPU. [Default: 50ms]'
+                pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                 type: string
               iptablesLockTimeout:
                 description: 'IptablesLockTimeout is the time that Felix will wait
@@ -1374,8 +1453,10 @@ spec:
                   also take the lock. When running Felix inside a container, this
                   requires the /run directory of the host to be mounted into the calico/node
                   or calico/felix container. [Default: 0s disabled]'
+                pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                 type: string
               iptablesMangleAllowAction:
+                pattern: ^(?i)(Accept|Return)?$
                 type: string
               iptablesMarkMask:
                 description: 'IptablesMarkMask is the mask that Felix selects its
@@ -1392,6 +1473,7 @@ spec:
                   back in order to check the write was not clobbered by another process.
                   This should only occur if another application on the system doesn''t
                   respect the iptables lock. [Default: 1s]'
+                pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                 type: string
               iptablesRefreshInterval:
                 description: 'IptablesRefreshInterval is the period at which Felix
@@ -1402,6 +1484,7 @@ spec:
                   was fixed in kernel version 4.11. If you are using v4.11 or greater
                   you may want to set this to, a higher value to reduce Felix CPU
                   usage. [Default: 10s]'
+                pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                 type: string
               ipv6Support:
                 description: IPv6Support controls whether Felix enables support for
@@ -1436,15 +1519,18 @@ spec:
               logSeverityFile:
                 description: 'LogSeverityFile is the log severity above which logs
                   are sent to the log file. [Default: Info]'
+                pattern: ^(?i)(Debug|Info|Warning|Error|Fatal)?$
                 type: string
               logSeverityScreen:
                 description: 'LogSeverityScreen is the log severity above which logs
                   are sent to the stdout. [Default: Info]'
+                pattern: ^(?i)(Debug|Info|Warning|Error|Fatal)?$
                 type: string
               logSeveritySys:
                 description: 'LogSeveritySys is the log severity above which logs
                   are sent to the syslog. Set to None for no logging to syslog. [Default:
                   Info]'
+                pattern: ^(?i)(Debug|Info|Warning|Error|Fatal)?$
                 type: string
               maxIpsetSize:
                 type: integer
@@ -1483,6 +1569,7 @@ spec:
                 pattern: ^.*
                 x-kubernetes-int-or-string: true
               netlinkTimeout:
+                pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                 type: string
               openstackRegion:
                 description: 'OpenstackRegion is the name of the region that a particular
@@ -1537,21 +1624,25 @@ spec:
                 description: 'ReportingInterval is the interval at which Felix reports
                   its status into the datastore or 0 to disable. Must be non-zero
                   in OpenStack deployments. [Default: 30s]'
+                pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                 type: string
               reportingTTL:
                 description: 'ReportingTTL is the time-to-live setting for process-wide
                   status reports. [Default: 90s]'
+                pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                 type: string
               routeRefreshInterval:
                 description: 'RouteRefreshInterval is the period at which Felix re-checks
                   the routes in the dataplane to ensure that no other process has
                   accidentally broken Calico''s rules. Set to 0 to disable route refresh.
                   [Default: 90s]'
+                pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                 type: string
               routeSource:
                 description: 'RouteSource configures where Felix gets its routing
                   information. - WorkloadIPs: use workload endpoints to construct
                   routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
+                pattern: ^(?i)(WorkloadIPs|CalicoIPAM)?$
                 type: string
               routeSyncDisabled:
                 description: RouteSyncDisabled will disable all operations performed
@@ -1591,6 +1682,7 @@ spec:
                   packets that do not get DNAT''d by kube-proxy. Unless set to "Disabled",
                   in which case such routing loops continue to be allowed. [Default:
                   Drop]'
+                pattern: ^(?i)(Drop|Reject|Disabled)?$
                 type: string
               sidecarAccelerationEnabled:
                 description: 'SidecarAccelerationEnabled enables experimental sidecar
@@ -1606,10 +1698,12 @@ spec:
               usageReportingInitialDelay:
                 description: 'UsageReportingInitialDelay controls the minimum delay
                   before Felix makes a report. [Default: 300s]'
+                pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                 type: string
               usageReportingInterval:
                 description: 'UsageReportingInterval controls the interval at which
                   Felix makes reports. [Default: 86400s]'
+                pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                 type: string
               useInternalDataplaneDriver:
                 description: UseInternalDataplaneDriver, if true, Felix will use its
@@ -1633,6 +1727,14 @@ spec:
                 type: integer
               vxlanVNI:
                 type: integer
+              windowsManageFirewallRules:
+                description: 'WindowsManageFirewallRules configures whether or not
+                  Felix will program Windows Firewall rules. (to allow inbound access
+                  to its own metrics ports) [Default: Disabled]'
+                enum:
+                - Enabled
+                - Disabled
+                type: string
               wireguardEnabled:
                 description: 'WireguardEnabled controls whether Wireguard is enabled
                   for IPv4 (encapsulating IPv4 traffic over an IPv4 underlay network).
@@ -1658,6 +1760,7 @@ spec:
               wireguardKeepAlive:
                 description: 'WireguardKeepAlive controls Wireguard PersistentKeepalive
                   option. Set 0 to disable. [Default: 0]'
+                pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                 type: string
               wireguardListeningPort:
                 description: 'WireguardListeningPort controls the listening port used
@@ -1684,6 +1787,7 @@ spec:
                   the allowedSourcePrefixes annotation to send traffic with a source
                   IP address that is not theirs. This is disabled by default. When
                   set to "Any", pods can request any prefix.
+                pattern: ^(?i)(Disabled|Any)?$
                 type: string
               xdpEnabled:
                 description: 'XDPEnabled enables XDP acceleration for suitable untracked
@@ -1694,6 +1798,7 @@ spec:
                   all XDP state to ensure that no other process has accidentally broken
                   Calico''s BPF maps or attached programs. Set to 0 to disable XDP
                   refresh. [Default: 90s]'
+                pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                 type: string
             type: object
         type: object
@@ -2508,6 +2613,19 @@ spec:
                   with identical order will be applied in alphanumerical order based
                   on the Policy "Name".
                 type: number
+              performanceHints:
+                description: "PerformanceHints contains a list of hints to Calico's
+                  policy engine to help process the policy more efficiently.  Hints
+                  never change the enforcement behaviour of the policy. \n Currently,
+                  the only available hint is \"AssumeNeededOnEveryNode\".  When that
+                  hint is set on a policy, Felix will act as if the policy matches
+                  a local endpoint even if it does not. This is useful for \"preloading\"
+                  any large static policies that are known to be used on every node.
+                  If the policy is _not_ used on a particular node then the work done
+                  to preload the policy (and to maintain it) is wasted."
+                items:
+                  type: string
+                type: array
               preDNAT:
                 description: PreDNAT indicates to apply the rules in this policy before
                   any DNAT.
@@ -4167,6 +4285,19 @@ spec:
                   with identical order will be applied in alphanumerical order based
                   on the Policy "Name".
                 type: number
+              performanceHints:
+                description: "PerformanceHints contains a list of hints to Calico's
+                  policy engine to help process the policy more efficiently.  Hints
+                  never change the enforcement behaviour of the policy. \n Currently,
+                  the only available hint is \"AssumeNeededOnEveryNode\".  When that
+                  hint is set on a policy, Felix will act as if the policy matches
+                  a local endpoint even if it does not. This is useful for \"preloading\"
+                  any large static policies that are known to be used on every node.
+                  If the policy is _not_ used on a particular node then the work done
+                  to preload the policy (and to maintain it) is wasted."
+                items:
+                  type: string
+                type: array
               selector:
                 description: "The selector is an expression used to pick pick out
                   the endpoints that the policy should be applied to. \n Selector
@@ -4643,7 +4774,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: docker.io/calico/cni:v3.26.3
+          image: docker.io/calico/cni:v3.27.0
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
@@ -4671,7 +4802,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.26.3
+          image: docker.io/calico/cni:v3.27.0
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -4714,7 +4845,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: docker.io/calico/node:v3.26.3
+          image: docker.io/calico/node:v3.27.0
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -4740,7 +4871,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.26.3
+          image: docker.io/calico/node:v3.27.0
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -4957,7 +5088,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.26.3
+          image: docker.io/calico/kube-controllers:v3.27.0
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.

--- a/katalog/calico/kustomization.yaml
+++ b/katalog/calico/kustomization.yaml
@@ -10,15 +10,12 @@ namespace: kube-system
 images:
 - name: docker.io/calico/cni
   newName: registry.sighup.io/fury/calico/cni
-  newTag: v3.26.3
 - name: docker.io/calico/kube-controllers
   newName: registry.sighup.io/fury/calico/kube-controllers
-  newTag: v3.26.3
 - name: docker.io/calico/node
   newName: registry.sighup.io/fury/calico/node
-  newTag: v3.26.3
 
-  # Resources needed for Monitoring
+# Resources needed for Monitoring
 resources:
 - deploy.yaml
 - monitoring


### PR DESCRIPTION
This PR upgrades the Standalone Calico installation to version 3.27.0.

- [Upgrade reference](https://docs.tigera.io/calico/latest/operations/upgrading/kubernetes-upgrade)