### PR TITLE
Feat: update calico add compatibility to 1.29, release v1.17.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -397,6 +397,338 @@ volumes:
     host:
       path: /var/run/docker.sock
 ---
+name: e2e-kubernetes-1.26-tigera-operator
+kind: pipeline
+type: docker
+
+depends_on:
+  - policeman
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/heads/master
+      - refs/heads/main
+      - refs/tags/**
+
+steps:
+  - name: create Kind cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    pull: always
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_VERSION: v1.26.6
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      # /drone/src is the default workdir for the pipeline
+      # using this folder we don't need to mount another
+      # shared volume between the steps
+      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+    commands:
+      # create a custom config to disable Kind's default CNI so
+      # we can test using KFD's networking module.
+      - |
+        cat <<EOF > kind-config.yaml
+        kind: Cluster
+        apiVersion: kind.x-k8s.io/v1alpha4
+        networking:
+          disableDefaultCNI: true
+        EOF
+      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
+      # does not work when disabling the default CNI. It will always go in timeout.
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config kind-config.yaml
+      # save the kubeconfig so we can use it from other steps.
+      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
+
+  - name: e2e
+    # KUBECTL 1.27.1 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
+    image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.1.1_1.9.4_1.26.3_3.5.3_4.33.3
+    pull: always
+    network_mode: host
+    environment:
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+      FURYCTL_VERSION: v0.28.0
+    depends_on: [create Kind cluster]
+    commands:
+      - bats -t katalog/tests/calico/tigera.sh
+
+  - name: delete-kind-cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+    commands:
+      # does not matter if the command fails
+      - kind delete cluster --name $${CLUSTER_NAME} || true
+    depends_on:
+      - e2e
+    when:
+      status:
+        - success
+        - failure
+
+volumes:
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
+---
+name: e2e-kubernetes-1.27-tigera-operator
+kind: pipeline
+type: docker
+
+depends_on:
+  - e2e-kubernetes-1.26-tigera-operator
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/heads/master
+      - refs/heads/main
+      - refs/tags/**
+
+steps:
+  - name: create Kind cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    pull: always
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_VERSION: v1.27.3
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      # /drone/src is the default workdir for the pipeline
+      # using this folder we don't need to mount another
+      # shared volume between the steps
+      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+    commands:
+      # create a custom config to disable Kind's default CNI so
+      # we can test using KFD's networking module.
+      - |
+        cat <<EOF > kind-config.yaml
+        kind: Cluster
+        apiVersion: kind.x-k8s.io/v1alpha4
+        networking:
+          disableDefaultCNI: true
+        EOF
+      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
+      # does not work when disabling the default CNI. It will always go in timeout.
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config kind-config.yaml
+      # save the kubeconfig so we can use it from other steps.
+      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
+
+  - name: e2e
+    # KUBECTL 1.27.1 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
+    image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.1.1_1.9.4_1.26.3_3.5.3_4.33.3
+    pull: always
+    network_mode: host
+    environment:
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+      FURYCTL_VERSION: v0.28.0
+    depends_on: [create Kind cluster]
+    commands:
+      - bats -t katalog/tests/calico/tigera.sh
+
+  - name: delete-kind-cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+    commands:
+      # does not matter if the command fails
+      - kind delete cluster --name $${CLUSTER_NAME} || true
+    depends_on:
+      - e2e
+    when:
+      status:
+        - success
+        - failure
+
+volumes:
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
+---
+name: e2e-kubernetes-1.28-tigera-operator
+kind: pipeline
+type: docker
+
+depends_on:
+  - e2e-kubernetes-1.27-tigera-operator
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/heads/master
+      - refs/heads/main
+      - refs/tags/**
+
+steps:
+  - name: create Kind cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    pull: always
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_VERSION: v1.28.0
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      # /drone/src is the default workdir for the pipeline
+      # using this folder we don't need to mount another
+      # shared volume between the steps
+      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+    commands:
+      # create a custom config to disable Kind's default CNI so
+      # we can test using KFD's networking module.
+      - |
+        cat <<EOF > kind-config.yaml
+        kind: Cluster
+        apiVersion: kind.x-k8s.io/v1alpha4
+        networking:
+          disableDefaultCNI: true
+        EOF
+      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
+      # does not work when disabling the default CNI. It will always go in timeout.
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config kind-config.yaml
+      # save the kubeconfig so we can use it from other steps.
+      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
+
+  - name: e2e
+    # KUBECTL 1.27.1 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
+    image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.1.1_1.9.4_1.26.3_3.5.3_4.33.3
+    pull: always
+    network_mode: host
+    environment:
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+      FURYCTL_VERSION: v0.28.0
+    depends_on: [create Kind cluster]
+    commands:
+      - bats -t katalog/tests/calico/tigera.sh
+
+  - name: delete-kind-cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+    commands:
+      # does not matter if the command fails
+      - kind delete cluster --name $${CLUSTER_NAME} || true
+    depends_on:
+      - e2e
+    when:
+      status:
+        - success
+        - failure
+
+volumes:
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
+---
+name: e2e-kubernetes-1.29-tigera-operator
+kind: pipeline
+type: docker
+
+depends_on:
+  - e2e-kubernetes-1.28-tigera-operator
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/heads/master
+      - refs/heads/main
+      - refs/tags/**
+
+steps:
+  - name: create Kind cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    pull: always
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_VERSION: v1.29.0
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      # /drone/src is the default workdir for the pipeline
+      # using this folder we don't need to mount another
+      # shared volume between the steps
+      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+    commands:
+      # create a custom config to disable Kind's default CNI so
+      # we can test using KFD's networking module.
+      - |
+        cat <<EOF > kind-config.yaml
+        kind: Cluster
+        apiVersion: kind.x-k8s.io/v1alpha4
+        networking:
+          disableDefaultCNI: true
+        EOF
+      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
+      # does not work when disabling the default CNI. It will always go in timeout.
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config kind-config.yaml
+      # save the kubeconfig so we can use it from other steps.
+      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
+
+  - name: e2e
+    # KUBECTL 1.27.1 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
+    image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.1.1_1.9.4_1.26.3_3.5.3_4.33.3
+    pull: always
+    network_mode: host
+    environment:
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+      FURYCTL_VERSION: v0.28.0
+    depends_on: [create Kind cluster]
+    commands:
+      - bats -t katalog/tests/calico/tigera.sh
+
+  - name: delete-kind-cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+    commands:
+      # does not matter if the command fails
+      - kind delete cluster --name $${CLUSTER_NAME} || true
+    depends_on:
+      - e2e
+    when:
+      status:
+        - success
+        - failure
+
+volumes:
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
+---
 name: e2e-kubernetes-1.26-cilium
 kind: pipeline
 type: docker
@@ -750,6 +1082,10 @@ depends_on:
   - e2e-kubernetes-1.27-calico
   - e2e-kubernetes-1.28-calico
   - e2e-kubernetes-1.29-calico
+  - e2e-kubernetes-1.26-tigera-operator
+  - e2e-kubernetes-1.27-tigera-operator
+  - e2e-kubernetes-1.28-tigera-operator
+  - e2e-kubernetes-1.29-tigera-operator
   - e2e-kubernetes-1.26-cilium
   - e2e-kubernetes-1.27-cilium
   - e2e-kubernetes-1.28-cilium

--- a/.drone.yml
+++ b/.drone.yml
@@ -402,7 +402,7 @@ kind: pipeline
 type: docker
 
 depends_on:
-  - policeman
+  - e2e-kubernetes-1.29-calico
 
 platform:
   os: linux
@@ -734,7 +734,7 @@ kind: pipeline
 type: docker
 
 depends_on:
-  - policeman
+  - e2e-kubernetes-1.29-tigera-operator
 
 platform:
   os: linux

--- a/.drone.yml
+++ b/.drone.yml
@@ -121,7 +121,7 @@ steps:
     environment:
       CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
-      FURYCTL_VERSION: v0.27.2
+      FURYCTL_VERSION: v0.28.0
     depends_on: [create Kind cluster]
     commands:
       - bats -t katalog/tests/calico/calico.sh
@@ -204,7 +204,7 @@ steps:
     environment:
       CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
-      FURYCTL_VERSION: v0.27.2
+      FURYCTL_VERSION: v0.28.0
     depends_on: [create Kind cluster]
     commands:
       - bats -t katalog/tests/calico/calico.sh
@@ -287,7 +287,90 @@ steps:
     environment:
       CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
-      FURYCTL_VERSION: v0.27.2
+      FURYCTL_VERSION: v0.28.0
+    depends_on: [create Kind cluster]
+    commands:
+      - bats -t katalog/tests/calico/calico.sh
+
+  - name: delete-kind-cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+    commands:
+      # does not matter if the command fails
+      - kind delete cluster --name $${CLUSTER_NAME} || true
+    depends_on:
+      - e2e
+    when:
+      status:
+        - success
+        - failure
+
+volumes:
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
+---
+name: e2e-kubernetes-1.29-calico
+kind: pipeline
+type: docker
+
+depends_on:
+  - e2e-kubernetes-1.28-calico
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/heads/master
+      - refs/heads/main
+      - refs/tags/**
+
+steps:
+  - name: create Kind cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    pull: always
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_VERSION: v1.29.0
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      # /drone/src is the default workdir for the pipeline
+      # using this folder we don't need to mount another
+      # shared volume between the steps
+      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+    commands:
+      # create a custom config to disable Kind's default CNI so
+      # we can test using KFD's networking module.
+      - |
+        cat <<EOF > kind-config.yaml
+        kind: Cluster
+        apiVersion: kind.x-k8s.io/v1alpha4
+        networking:
+          disableDefaultCNI: true
+        EOF
+      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
+      # does not work when disabling the default CNI. It will always go in timeout.
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config kind-config.yaml
+      # save the kubeconfig so we can use it from other steps.
+      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
+
+  - name: e2e
+    # KUBECTL 1.27.1 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
+    image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.1.1_1.9.4_1.26.3_3.5.3_4.33.3
+    pull: always
+    network_mode: host
+    environment:
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+      FURYCTL_VERSION: v0.28.0
     depends_on: [create Kind cluster]
     commands:
       - bats -t katalog/tests/calico/calico.sh
@@ -373,7 +456,7 @@ steps:
     environment:
       CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
-      FURYCTL_VERSION: v0.27.2
+      FURYCTL_VERSION: v0.28.0
     depends_on: [create Kind cluster]
     commands:
       - bats -t katalog/tests/cilium/cilium.sh
@@ -459,7 +542,7 @@ steps:
     environment:
       CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
-      FURYCTL_VERSION: v0.27.2
+      FURYCTL_VERSION: v0.28.0
     depends_on: [create Kind cluster]
     commands:
       - bats -t katalog/tests/cilium/cilium.sh
@@ -545,7 +628,93 @@ steps:
     environment:
       CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
-      FURYCTL_VERSION: v0.27.2
+      FURYCTL_VERSION: v0.28.0
+    depends_on: [create Kind cluster]
+    commands:
+      - bats -t katalog/tests/cilium/cilium.sh
+
+  - name: delete-kind-cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+    commands:
+      # does not matter if the command fails
+      - kind delete cluster --name $${CLUSTER_NAME} || true
+    depends_on:
+      - e2e
+    when:
+      status:
+        - success
+        - failure
+
+volumes:
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
+---
+name: e2e-kubernetes-1.29-cilium
+kind: pipeline
+type: docker
+
+depends_on:
+  - e2e-kubernetes-1.28-cilium
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/heads/master
+      - refs/heads/main
+      - refs/tags/**
+
+steps:
+  - name: create Kind cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    pull: always
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_VERSION: v1.29.0
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      # /drone/src is the default workdir for the pipeline
+      # using this folder we don't need to mount another
+      # shared volume between the steps
+      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+    commands:
+      # create a custom config to disable Kind's default CNI so
+      # we can test using KFD's networking module.
+      - |
+        cat <<EOF > kind-config.yaml
+        kind: Cluster
+        apiVersion: kind.x-k8s.io/v1alpha4
+        networking:
+          disableDefaultCNI: true
+        nodes:
+        - role: control-plane
+        - role: worker
+        EOF
+      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
+      # does not work when disabling the default CNI. It will always go in timeout.
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config kind-config.yaml
+      # save the kubeconfig so we can use it from other steps.
+      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
+
+  - name: e2e
+    # KUBECTL 1.27.1 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
+    image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.1.1_1.9.4_1.26.3_3.5.3_4.33.3
+    pull: always
+    network_mode: host
+    environment:
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+      FURYCTL_VERSION: v0.28.0
     depends_on: [create Kind cluster]
     commands:
       - bats -t katalog/tests/cilium/cilium.sh
@@ -580,9 +749,11 @@ depends_on:
   - e2e-kubernetes-1.26-calico
   - e2e-kubernetes-1.27-calico
   - e2e-kubernetes-1.28-calico
+  - e2e-kubernetes-1.29-calico
   - e2e-kubernetes-1.26-cilium
   - e2e-kubernetes-1.27-cilium
   - e2e-kubernetes-1.28-cilium
+  - e2e-kubernetes-1.29-cilium
 
 platform:
   os: linux

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </h1>
 <!-- markdownlint-enable MD033 -->
 
-![Release](https://img.shields.io/badge/Latest%20Release-v1.15.2-blue)
+![Release](https://img.shields.io/badge/Latest%20Release-v1.16.1-blue)
 ![License](https://img.shields.io/github/license/sighupio/fury-kubernetes-networking?label=License)
 ![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)
 
@@ -29,9 +29,9 @@ Kubernetes Fury Networking provides the following packages:
 
 | Package                    | Version  | Description                                                                                                                                          |
 | -------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [calico](katalog/calico)   | `3.27.0` | [Calico][calico-page] CNI Plugin. For cluster with `< 50` nodes.                                                                                     |
+| [calico](katalog/calico)   | `3.27.3` | [Calico][calico-page] CNI Plugin. For cluster with `< 50` nodes.                                                                                     |
 | [cilium](katalog/cilium)   | `1.15.2` | [Cilium][cilium-page] CNI Plugin. For cluster with `< 200` nodes.                                                                                    |
-| [tigera](katalog/tigera)   | `1.32.3` | [Tigera Operator][tigera-page], a Kubernetes Operator for Calico, provides pre-configured installations for on-prem and for EKS in policy-only mode. |
+| [tigera](katalog/tigera)   | `1.32.7` | [Tigera Operator][tigera-page], a Kubernetes Operator for Calico, provides pre-configured installations for on-prem and for EKS in policy-only mode. |
 | [ip-masq](katalog/ip-masq) | `2.8.0`  | The `ip-masq-agent` configures iptables rules to implement IP masquerading functionality                                                             |
 
 > The resources in these packages are going to be deployed in `kube-system` namespace. Except for the operator.
@@ -45,6 +45,7 @@ Click on each package to see its full documentation.
 | `1.26.x`           | :white_check_mark: | No known issues |
 | `1.27.x`           | :white_check_mark: | No known issues |
 | `1.28.x`           | :white_check_mark: | No known issues |
+| `1.29.x`           | :white_check_mark: | No known issues |
 
 
 Check the [compatibility matrix][compatibility-matrix] for additional information on previous releases of the module.
@@ -67,7 +68,7 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 ```yaml
 bases:
   - name: networking
-    version: "v1.16.0"
+    version: "v1.16.1"
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </h1>
 <!-- markdownlint-enable MD033 -->
 
-![Release](https://img.shields.io/badge/Latest%20Release-v1.16.1-blue)
+![Release](https://img.shields.io/badge/Latest%20Release-v1.17.0-blue)
 ![License](https://img.shields.io/github/license/sighupio/fury-kubernetes-networking?label=License)
 ![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)
 
@@ -68,7 +68,7 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 ```yaml
 bases:
   - name: networking
-    version: "v1.16.1"
+    version: "v1.17.0"
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -1,15 +1,16 @@
 # Compatibility Matrix
 
-| Module Version / Kubernetes Version | 1.24.X             | 1.25.X             | 1.26.X             | 1.27.X             | 1.28.X             |
-| ----------------------------------- | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
-| v1.10.0                             | :white_check_mark: |                    |                    |                    |                    |
-| v1.11.0                             | :white_check_mark: | :white_check_mark: |                    |                    |                    |
-| v1.12.0                             | :white_check_mark: | :white_check_mark: |                    |                    |                    |
-| v1.12.1                             | :white_check_mark: | :white_check_mark: |                    |                    |                    |
-| v1.12.2                             | :white_check_mark: | :white_check_mark: |                    |                    |                    |
-| v1.14.0                             | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |
-| v1.15.0                             |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |
-| v1.16.0                             |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Module Version / Kubernetes Version | 1.24.X             | 1.25.X             | 1.26.X             | 1.27.X             | 1.28.X             | 1.29.X             |
+| ----------------------------------- | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
+| v1.10.0                             | :white_check_mark: |                    |                    |                    |                    |                    |
+| v1.11.0                             | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
+| v1.12.0                             | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
+| v1.12.1                             | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
+| v1.12.2                             | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
+| v1.14.0                             | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |
+| v1.15.0                             |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |
+| v1.16.0                             |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |
+| v1.17.0                             |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 
 :white_check_mark: Compatible

--- a/docs/releases/v1.16.1.md
+++ b/docs/releases/v1.16.1.md
@@ -2,7 +2,7 @@
 
 Welcome to the latest release of the `Networking` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
 
-This minor release updates some components and adds support to Kubernetes 1.29.
+This patch release updates some components and adds support to Kubernetes 1.29.
 
 ## Component Images 🚢
 

--- a/docs/releases/v1.16.1.md
+++ b/docs/releases/v1.16.1.md
@@ -1,0 +1,32 @@
+# Networking Core Module Release 1.16.1
+
+Welcome to the latest release of the `Networking` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+
+This minor release updates some components and adds support to Kubernetes 1.29.
+
+## Component Images 🚢
+
+| Component         | Supported Version                                                                | Previous Version |
+| ----------------- | -------------------------------------------------------------------------------- | ---------------- |
+| `calico`          | [`v3.27.3`](https://docs.tigera.io/calico/3.27/about/)                           | `v3.27.0`        |
+| `cilium`          | [`v1.15.2`](https://github.com/cilium/cilium/releases/tag/v1.15.2)               | No update        |
+| `ip-masq`         | [`v2.8.0`](https://github.com/kubernetes-sigs/ip-masq-agent/releases/tag/v2.8.0) | No update        |
+| `tigera-operator` | [`v1.32.7`](https://github.com/tigera/operator/releases/tag/v1.32.7)             | `v1.32.3`        |
+
+> Please refer the individual release notes to get detailed information on each release.
+
+## Update Guide 🦮
+
+### Process
+
+1. Just deploy as usual:
+
+```bash
+kustomize build katalog/calico | kubectl apply -f -
+# OR
+kustomize build katalog/tigera/on-prem | kubectl apply -f -
+# OR
+kustomize build katalog/cilium | kubectl apply -f -
+```
+
+If you are upgrading from previous versions, please refer to the [`v1.16.0` release notes](https://github.com/sighupio/fury-kubernetes-networking/releases/tag/v1.16.0).

--- a/docs/releases/v1.17.0.md
+++ b/docs/releases/v1.17.0.md
@@ -1,4 +1,4 @@
-# Networking Core Module Release 1.16.1
+# Networking Core Module Release 1.17.0
 
 Welcome to the latest release of the `Networking` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
 

--- a/katalog/calico/MAINTENANCE.md
+++ b/katalog/calico/MAINTENANCE.md
@@ -7,7 +7,7 @@ To update the Calico package with upstream, please follow the next steps:
 1. Download upstream manifests:
 
 ```bash
-export CALICO_VERSION=3.27.0
+export CALICO_VERSION=3.27.3
 curl -L https://raw.githubusercontent.com/projectcalico/calico/v${CALICO_VERSION}/manifests/calico.yaml -o calico-${CALICO_VERSION}.yaml
 ```
 
@@ -20,7 +20,7 @@ Compare the `deploy.yaml` file with the downloaded `calico-${CALICO_VERSION}` fi
 3. Update the `kustomization.yaml` file with the right image versions.
 
 ```bash
-export CALICO_IMAGE_TAG=v3.27.0
+export CALICO_IMAGE_TAG=v3.27.3
 kustomize edit set image docker.io/calico/kube-controllers=registry.sighup.io/fury/calico/kube-controllers:${CALICO_IMAGE_TAG}
 kustomize edit set image docker.io/calico/cni=registry.sighup.io/fury/calico/cni:${CALICO_IMAGE_TAG}
 kustomize edit set image docker.io/calico/node=registry.sighup.io/fury/calico/node:${CALICO_IMAGE_TAG}
@@ -39,7 +39,7 @@ See <https://docs.tigera.io/calico/latest/operations/monitor/monitor-component-m
 1. Download the dashboard from upstream:
 
 ```bash
-export CALICO_VERSION=3.27.0
+export CALICO_VERSION=3.27.3
 # ⚠️ Assuming $PWD == root of the project
 # We take the `felix-dashboard.json` from the downloaded yaml, we are not deploying `typha`, so we don't need its dashboard.
 curl -L https://raw.githubusercontent.com/projectcalico/calico/v${CALICO_VERSION}/manifests/grafana-dashboards.yaml | yq '.data["felix-dashboard.json"]' | sed 's/calico-demo-prometheus/prometheus/g' | jq > ./monitoring/dashboards/felix-dashboard.json

--- a/katalog/calico/README.md
+++ b/katalog/calico/README.md
@@ -21,9 +21,9 @@ The deployment of Calico consists of a daemon set running on every node (includi
 ## Image repository and tag
 
 - calico images:
-  - `calico/kube-controllers:v3.27.0`.
-  - `calico/cni:v3.27.0`.
-  - `calico/node:v3.27.0`.
+  - `calico/kube-controllers:v3.27.3`.
+  - `calico/cni:v3.27.3`.
+  - `calico/node:v3.27.3`.
 - calico repositories:
   - [https://github.com/projectcalico/kube-controllers](https://github.com/projectcalico/calico/tree/master/kube-controllers).
   - [https://github.com/projectcalico/cni-plugin](https://github.com/projectcalico/calico/tree/master/cni-plugin).

--- a/katalog/calico/kustomization.yaml
+++ b/katalog/calico/kustomization.yaml
@@ -10,13 +10,13 @@ namespace: kube-system
 images:
 - name: docker.io/calico/cni
   newName: registry.sighup.io/fury/calico/cni
-  newTag: v3.27.0
+  newTag: v3.27.3
 - name: docker.io/calico/kube-controllers
   newName: registry.sighup.io/fury/calico/kube-controllers
-  newTag: v3.27.0
+  newTag: v3.27.3
 - name: docker.io/calico/node
   newName: registry.sighup.io/fury/calico/node
-  newTag: v3.27.0
+  newTag: v3.27.3
 
   # Resources needed for Monitoring
 resources:

--- a/katalog/tests/calico/tigera.sh
+++ b/katalog/tests/calico/tigera.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2024-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 

--- a/katalog/tests/calico/tigera.sh
+++ b/katalog/tests/calico/tigera.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# shellcheck disable=SC2154
+
+load ./../helper
+
+@test "Nodes in Not Ready state" {
+    info
+    nodes_not_ready() {
+        kubectl get nodes --no-headers | awk  '{print $2}' | uniq | grep -q NotReady
+    }
+    run nodes_not_ready
+    [ "$status" -eq 0 ]
+}
+
+@test "Install Prerequisites" {
+    info
+    install() {
+        kubectl apply -f 'https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v2.0.1/katalog/prometheus-operator/crds/0servicemonitorCustomResourceDefinition.yaml'
+        kubectl apply -f 'https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v2.0.1/katalog/prometheus-operator/crds/0prometheusruleCustomResourceDefinition.yaml'
+    }
+    run install
+    [ "$status" -eq 0 ]
+}
+
+# 
+@test "Install Tigera operator and calico operated" {
+    info
+    test() {
+        apply katalog/tigera/on-prem
+    }
+    loop_it test 60 5
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Calico Kube Controller is Running" {
+    info
+    test() {
+        kubectl get pods -l k8s-app=calico-kube-controllers -o json -n calico-system |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+    }
+    loop_it test 60 5
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Calico Node is Running" {
+    info
+    test() {
+        kubectl get pods -l k8s-app=calico-node -o json -n calico-system |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+    }
+    loop_it test 60 5
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Nodes in ready State" {
+    info
+    test() {
+        kubectl get nodes --no-headers | awk  '{print $2}' | uniq | grep -q Ready
+    }
+    run test
+    [ "$status" -eq 0 ]
+}
+
+@test "Apply whitelist-system-ns GlobalNetworkPolicy" {
+    info
+    install() {
+        kubectl apply -f examples/globalnetworkpolicies/1.whitelist-system-namespace.yml
+    }
+    run install
+    [ "$status" -eq 0 ]
+}
+
+@test "Create a non-whitelisted namespace with an app" {
+    info
+    install() {
+        kubectl create ns test-1
+        kubectl apply -f katalog/tests/calico/resources/echo-server.yaml -n test-1
+        kubectl wait -n test-1 --for=condition=ready --timeout=120s pod -l app=echoserver
+    }
+    run install
+    [ "$status" -eq 0 ]
+}
+
+@test "Test app within the same namespace" {
+    info
+    test() {
+        kubectl create job -n test-1 isolated-test --image travelping/nettools -- curl http://echoserver.test-1.svc.cluster.local
+        kubectl wait -n test-1 --for=condition=complete --timeout=30s job/isolated-test
+    }
+    run test
+    [ "$status" -eq 0 ]
+}
+
+@test "Test app from a system namespace" {
+    info
+    test() {
+        kubectl create job -n kube-system isolated-test --image travelping/nettools -- curl http://echoserver.test-1.svc.cluster.local
+        kubectl wait -n kube-system --for=condition=complete --timeout=30s job/isolated-test
+    }
+    run test
+    [ "$status" -eq 0 ]
+}
+
+@test "Test app from a different namespace" {
+    info
+    test() {
+        kubectl create ns test-1-1
+        kubectl create job -n test-1-1 isolated-test --image travelping/nettools -- curl http://echoserver.test-1.svc.cluster.local
+        kubectl wait -n test-1-1 --for=condition=complete --timeout=30s job/isolated-test
+    }
+    run test
+    [ "$status" -eq 0 ]
+}
+
+@test "Apply deny-all GlobalNetworkPolicy" {
+    info
+    install() {
+        kubectl apply -f examples/globalnetworkpolicies/2000.deny-all.yml
+    }
+    run install
+    [ "$status" -eq 0 ]
+}
+
+@test "Test app from the same namespace (isolated namespace)" {
+    info
+    test() {
+        kubectl create job -n test-1 isolated-test-1 --image travelping/nettools -- curl http://echoserver.test-1.svc.cluster.local
+        kubectl wait -n test-1 --for=condition=complete --timeout=30s job/isolated-test-1
+    }
+    run test
+    [ "$status" -eq 1 ]
+}
+
+@test "Test app from a system namespace (isolated namespace)" {
+    info
+    test() {
+        kubectl create job -n kube-system isolated-test-1 --image travelping/nettools -- curl http://echoserver.test-1.svc.cluster.local
+        kubectl wait -n kube-system --for=condition=complete --timeout=30s job/isolated-test-1
+    }
+    run test
+    [ "$status" -eq 0 ]
+}
+
+@test "Test app from a different namespace (isolated namespace)" {
+    info
+    test() {
+        kubectl create job -n test-1-1 isolated-test-1 --image travelping/nettools -- curl http://echoserver.test-1.svc.cluster.local
+        kubectl wait -n test-1-1 --for=condition=complete --timeout=30s job/isolated-test-1
+    }
+    run test
+    [ "$status" -eq 1 ]
+}

--- a/katalog/tests/calico/tigera.sh
+++ b/katalog/tests/calico/tigera.sh
@@ -19,8 +19,8 @@ load ./../helper
 @test "Install Prerequisites" {
     info
     install() {
-        kubectl apply -f 'https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v2.0.1/katalog/prometheus-operator/crds/0servicemonitorCustomResourceDefinition.yaml'
-        kubectl apply -f 'https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v2.0.1/katalog/prometheus-operator/crds/0prometheusruleCustomResourceDefinition.yaml'
+        kubectl apply -f 'https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v3.1.0/katalog/prometheus-operator/crds/0servicemonitorCustomResourceDefinition.yaml'
+        kubectl apply -f 'https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v3.1.0/katalog/prometheus-operator/crds/0prometheusruleCustomResourceDefinition.yaml'
     }
     run install
     [ "$status" -eq 0 ]

--- a/katalog/tests/helper.bash
+++ b/katalog/tests/helper.bash
@@ -3,7 +3,7 @@
 
 apply (){
   kustomize build $1 >&2
-  kustomize build $1 | kubectl apply -f - 2>&3
+  kustomize build $1 | kubectl apply --server-side -f - 2>&3
 }
 
 delete (){

--- a/katalog/tigera/MAINTENANCE.md
+++ b/katalog/tigera/MAINTENANCE.md
@@ -11,7 +11,7 @@ To update the YAML file, run the following command:
 
 ```bash
 # assuming katalog/tigera is the root of the repository
-export CALICO_VERSION="3.27.0"
+export CALICO_VERSION="3.27.3"
 curl "https://raw.githubusercontent.com/projectcalico/calico/v${CALICO_VERSION}/manifests/tigera-operator.yaml" --output operator/tigera-operator.yaml
 ```
 
@@ -28,7 +28,7 @@ To download the default configuration from upstream and update the file use the 
 
 ```bash
 # assuming katalog/tigera is the root of the repository
-export CALICO_VERSION="3.27.0"
+export CALICO_VERSION="3.27.3"
 curl https://raw.githubusercontent.com/projectcalico/calico/v${CALICO_VERSION}/manifests/custom-resources.yaml --output on-prem/custom-resources.yaml
 ```
 
@@ -50,7 +50,7 @@ To get the dashboards you can use the following commands:
 
 ```bash
 # ⚠️ Assuming $PWD == root of the project
-export CALICO_VERSION="3.27.0"
+export CALICO_VERSION="3.27.3"
 # we split the upstream file and store only the json files
 curl -L https://raw.githubusercontent.com/projectcalico/calico/v${CALICO_VERSION}/manifests/grafana-dashboards.yaml | yq '.data["felix-dashboard.json"]' | sed 's/calico-demo-prometheus/prometheus/g' | jq > ./on-prem/monitoring/dashboards/felix-dashboard.json
 curl -L https://raw.githubusercontent.com/projectcalico/calico/v${CALICO_VERSION}/manifests/grafana-dashboards.yaml | yq '.data["typha-dashboard.json"]' | sed 's/calico-demo-prometheus/prometheus/g' | jq > ./on-prem/monitoring/dashboards/typa-dashboard.json

--- a/katalog/tigera/operator/tigera-operator.yaml
+++ b/katalog/tigera/operator/tigera-operator.yaml
@@ -983,6 +983,13 @@ spec:
                   Loose]'
                 pattern: ^(?i)(Disabled|Strict|Loose)?$
                 type: string
+              bpfExcludeCIDRsFromNAT:
+                description: BPFExcludeCIDRsFromNAT is a list of CIDRs that are to
+                  be excluded from NAT resolution so that host can handle them. A
+                  typical usecase is node local DNS cache.
+                items:
+                  type: string
+                type: array
               bpfExtToServiceConnmark:
                 description: 'BPFExtToServiceConnmark in BPF mode, control a 32bit
                   mark that is set on connections from an external client to a local
@@ -25102,6 +25109,14 @@ rules:
     verbs:
       - create
       - delete
+  # In addition to the above, the operator should have the ability to delete their own resources during uninstallation.
+  - apiGroups:
+      - operator.tigera.io
+    resources:
+      - installations
+      - apiservers
+    verbs:
+      - delete
   - apiGroups:
     - networking.k8s.io
     resources:
@@ -25273,7 +25288,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: tigera-operator
-          image: quay.io/tigera/operator:v1.32.3
+          image: quay.io/tigera/operator:v1.32.7
           imagePullPolicy: IfNotPresent
           command:
             - operator
@@ -25291,7 +25306,7 @@ spec:
             - name: OPERATOR_NAME
               value: "tigera-operator"
             - name: TIGERA_OPERATOR_INIT_IMAGE_VERSION
-              value: v1.32.3
+              value: v1.32.7
           envFrom:
             - configMapRef:
                 name: kubernetes-services-endpoint


### PR DESCRIPTION
This PR adds the support for kubernetes 1.29 and bumps calico to 3.27.3 and tigera operator to 1.32.7

Also, I added e2e tests for tigera operator, that was missing.

I also made the tests sequential, since the parallel execution was breaking too many times.