### PR TITLE
fix(calico): Added kubernetesProvider and nonPrivileged configurations

### DIFF
--- a/katalog/tigera/eks-policy-only/calico-crs.yaml
+++ b/katalog/tigera/eks-policy-only/calico-crs.yaml
@@ -11,6 +11,8 @@ kind: Installation
 metadata:
   name: default
 spec:
+  nonPrivileged: Disabled
+  kubernetesProvider: EKS
   registry: registry.sighup.io/
   imagePath: fury/calico
   # Configures Calico policy configured to work with AmazonVPC CNI networking.


### PR DESCRIPTION
This PR addresses #82 by adding specific configurations for Calico in EKS. The issue was related to panic and sysctl errors, especially:
``` bash
2024-10-12 12:09:47.350 [PANIC][9460] felix/table.go 784: iptables-legacy-save command failed after retries ipVersion=0x4 table="raw"
2024-10-12 12:09:48.485 [ERROR][9510] felix/int_dataplane.go 2065: Failed to set IPv4 forwarding sysctl error=open /proc/sys/net/ipv4/ip_forward: read-only file system
```

**Changes:**

- Added kubernetesProvider: Specifies the Kubernetes platform provider (EKS), allowing automatic provider-specific configurations.

- Added nonPrivileged: Ensures Calico runs in non-privileged mode as a non-root user where possible.