### PR TITLE
feat: cilium extract PKI to separated resource and extend CA cert expiry

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,42 @@
+# Networking Core Module Release vTBD
+
+Welcome to the latest release of the `Networking` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+
+## Important changes ℹ️
+
+- [[#87](https://github.com/sighupio/fury-kubernetes-networking/pull/87)] Changed the duration for Cilium's mTLS self-signed CA certificate to 10 years. See the update guide for more information.
+
+## Component Images 🚢
+
+| Component         | Supported Version                                                                | Previous Version |
+| ----------------- | -------------------------------------------------------------------------------- | ---------------- |
+| `cilium`          | [`v1.16.3`](https://github.com/cilium/cilium/releases/tag/v1.15.2)               | No update        |
+| `ip-masq`         | [`v2.8.0`](https://github.com/kubernetes-sigs/ip-masq-agent/releases/tag/v2.8.0) | No update        |
+| `tigera-operator` | [`v1.36.1`](https://github.com/tigera/operator/releases/tag/v1.36.1)             | No update        |
+
+> Please refer the individual release notes to get detailed information on each release.
+
+## Breaking Changes 💔
+
+- None
+
+## Update Guide 🦮
+
+### Process
+
+1. Just deploy as usual:
+
+```bash
+kustomize build katalog/tigera/on-prem | kubectl apply --server-side -f -
+# OR
+kustomize build katalog/cilium | kubectl apply --server-side -f -
+```
+
+2. (Cilium only) After applying the new version, you will need to manually trigger the renewal of the mTLS certificates for Cilium:
+
+```bash
+cmctl renew -n kube-system hubble-relay-client-certs
+cmctl renew -n kube-system hubble-server-certs
+```
+
+Note: you will need cert-manager's CLI [`cmctl`](https://cert-manager.io/docs/reference/cmctl/) installed.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -2,9 +2,9 @@
 
 Welcome to the latest release of the `Networking` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
 
-## Important changes ℹ️
+## Bug fixes 🐞
 
-- [[#87](https://github.com/sighupio/fury-kubernetes-networking/pull/87)] Changed the duration for Cilium's mTLS self-signed CA certificate to 10 years. See the update guide for more information.
+- [[#87](https://github.com/sighupio/fury-kubernetes-networking/pull/87)] **Extended Cilium's mTLS selfg-signed CA certificated duration to 10 years** instead of having them expire before the peer certificates to avoid breaking communication. See the update guide below for more information on additional steps needed after updating.
 
 ## Component Images 🚢
 

--- a/katalog/cilium/.gitignore
+++ b/katalog/cilium/.gitignore
@@ -1,0 +1,3 @@
+local-with-hubble.yaml
+upstream-with-hubble.yaml
+upstream-without-hubble.yaml

--- a/katalog/cilium/MAINTENANCE.md
+++ b/katalog/cilium/MAINTENANCE.md
@@ -2,7 +2,9 @@
 
 To update the Cilium package with upstream, please follow the next steps.
 
-Download the upstream manifests:
+## 1. Updating the values file
+
+1.1. Download the upstream manifests
 
 ```bash
 helm repo add cilium https://helm.cilium.io/
@@ -11,51 +13,60 @@ helm search repo cilium/cilium
 helm pull cilium/cilium --version 1.16.3 --untar --untardir /tmp
 ```
 
-Change the tag for the images on the file `MAINTENANCE.values.yaml`, check the
-new one on `/tmp/cilium/values.yaml`
+1.2. Compare the `MAINTENANCE.values.yaml`with the one from the chart `/tmp/cilium/values.yaml` and port the changes that are needed. For example, update the image tags and check that parameters that were in use are still valid.
 
-Render the manifests:
+> 💡 **TIP**
+> You can a YAML and Kubernetes-aware tool like [Dyff](https://github.com/homeport/dyff) to compare the files. Dyff will help you to identify the differences between the manifests in a more human-readable way.
+> For example:
+>
+> ```bash
+> dyff between --ignore-whitespace-changes --ignore-order-changes /tmp/cilium/values.yaml MAINTENANCE.values.yaml
+> ```
+
+## 2. Updating the core package
+
+2.1. Render the manifests from the upstream Chart
 
 ```bash
-# before running helm template, remove from the /tmp/cilium/templates/validate.yaml
-# the ServiceMonitor capability check, otherwise it will not work
-helm template cilium /tmp/cilium --namespace kube-system --values MAINTENANCE.values.yaml > built-with-hubble.yaml
-helm template cilium /tmp/cilium --namespace kube-system --values MAINTENANCE.values.yaml \
+helm template cilium /tmp/cilium \
+  --namespace kube-system \
+  --values MAINTENANCE.values.yaml \
   --set hubble.enabled=false \
   --set hubble.relay.enabled=false \
   --set hubble.ui.enabled=false \
-  --set hubble.metrics.enabled=null > built-without-hubble.yaml
+  --set hubble.metrics.enabled=null \
+  --set prometheus.serviceMonitor.trustCRDsExist=true \
+  > upstream-without-hubble.yaml
 ```
 
-You need one version with hubble enabled and one version with hubble disabled, to
-check differences between the two deployments and assure that the folder `hubble`
-contains the correct patches to cilium without hubble, `core` folder.
+2.2. Check the differences between the manifests. Compare `core/deploy.yaml` against `upstream-without-hubble.yaml` and update `deploy.yaml` with the changes from the new version in `upstream-without-hubble.yaml` that need to be included.
 
-Check differences between `core/deploy.yaml` and `built-without-hubble.yaml` and
-update accordingly.
+## 3. Updating the hubble package
 
-Then, create a dummy kustomization project with the file `built-with-hubble.yaml`
-as resource, and build it:
+3.1. Render the manifests from the upstream Chart with Hubble enabled:
 
 ```bash
-mkdir dummy
-cp built-with-hubble.yaml dummy
-echo -e "resources:\n- built-with-hubble.yaml" > dummy/kustomization.yaml
-kustomize build dummy > built-from-helm.yaml
-# Now build the current project:
-kustomize build . > built.yaml
+helm template cilium /tmp/cilium \
+  --namespace kube-system \
+  --values MAINTENANCE.values.yaml \
+  --set prometheus.serviceMonitor.trustCRDsExist=true \
+  > upstream-with-hubble.yaml
 ```
 
-And check the differences betweeen `built-from-helm.yaml` and `built.yaml`
+3.2. Build the kustomization project for `hubble`:
 
-Beware that we changed how we generate the base CA from helm to cert-manager using
-a self-signed CA, and also, we fixed the ServiceMonitor for the hubble metrics,
-adding a target port on the cilium service and changing the target of the hubble
-ServiceMonitor.
-
-Once you're done aligning the manifest with upstream, replace the old one `hubble/deploy.yaml`
-with the newly built `built.yaml`:
-
-```sh
-mv built.yaml hubble/deploy.yaml
+```bash
+kustomize build hubble > local-with-hubble.yaml
 ```
+
+3.3  Compare the output againts the file `upstream-with-hubble.yaml` to check the differences and port the changes needed to the `hubble` package modifying the `hubble/deploy.yaml` file accordingly.
+
+### Expected differences with upstream in the Hubble package
+
+- The monitoring resources are not included in the upstream Helm chart.
+- The `self-signed-pki` resources (Issuers and CA certificates) are not included in the upstream Helm chart and have been manually added via Kustomize.
+- The ServiceMonitor for the hubble metrics was fixed adding a target port on the cilium service and changing the target of the hubble ServiceMonitor.
+
+> 💡 **TIP**
+> You can comment out the monitoring resources in the `core` and `hubble`'s `kustomization.yaml` files in step 3.2 to reduce the number of differences.
+> You can also comment out the self-signed-pki resource in `hubble`'s `kustomization.yaml` file to reduce the number of differences.

--- a/katalog/cilium/MAINTENANCE.md
+++ b/katalog/cilium/MAINTENANCE.md
@@ -16,7 +16,7 @@ helm pull cilium/cilium --version 1.16.3 --untar --untardir /tmp
 1.2. Compare the `MAINTENANCE.values.yaml`with the one from the chart `/tmp/cilium/values.yaml` and port the changes that are needed. For example, update the image tags and check that parameters that were in use are still valid.
 
 > 💡 **TIP**
-> You can a YAML and Kubernetes-aware tool like [Dyff](https://github.com/homeport/dyff) to compare the files. Dyff will help you to identify the differences between the manifests in a more human-readable way.
+> You can use a YAML and Kubernetes-aware tool like [Dyff](https://github.com/homeport/dyff) to compare the files. Dyff will help you to identify the differences between the manifests in a more human-readable way.
 > For example:
 >
 > ```bash

--- a/katalog/cilium/MAINTENANCE.md
+++ b/katalog/cilium/MAINTENANCE.md
@@ -13,7 +13,7 @@ helm search repo cilium/cilium
 helm pull cilium/cilium --version 1.16.3 --untar --untardir /tmp
 ```
 
-1.2. Compare the `MAINTENANCE.values.yaml`with the one from the chart `/tmp/cilium/values.yaml` and port the changes that are needed. For example, update the image tags and check that parameters that were in use are still valid.
+1.2. Compare the `MAINTENANCE.values.yaml` with the one from the chart `/tmp/cilium/values.yaml` and port the changes that are needed. For example, update the image tags and check that parameters that were in use are still valid.
 
 > 💡 **TIP**
 > You can use a YAML and Kubernetes-aware tool like [Dyff](https://github.com/homeport/dyff) to compare the files. Dyff will help you to identify the differences between the manifests in a more human-readable way.
@@ -70,3 +70,5 @@ kustomize build hubble > local-with-hubble.yaml
 > 💡 **TIP**
 > You can comment out the monitoring resources in the `core` and `hubble`'s `kustomization.yaml` files in step 3.2 to reduce the number of differences.
 > You can also comment out the self-signed-pki resource in `hubble`'s `kustomization.yaml` file to reduce the number of differences.
+>
+> Remember to uncomment the Kustomize project before releasing.

--- a/katalog/cilium/hubble/deploy.yaml
+++ b/katalog/cilium/hubble/deploy.yaml
@@ -39,28 +39,6 @@ data:
     tls-hubble-server-ca-files: /var/lib/hubble-relay/tls/hubble-server-ca.crt
     disable-server-tls: true
 ---
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: self-signed-cilium
-  namespace: kube-system
-spec:
-  selfSigned: {}
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: hubble-ca-secret
-  namespace: kube-system
-spec:
-  secretName: hubble-ca-secret
-  isCA: true
-  issuerRef:
-    # issuer created in step 1
-    name: self-signed-cilium
-    kind: Issuer
-  commonName: "cilium-ca"
----
 # Source: cilium/templates/hubble-ui/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -474,16 +452,6 @@ spec:
   duration: 26280h0m0s
   privateKey:
     rotationPolicy: Always
----
-# Source: cilium/templates/hubble/tls-certmanager/hubble-issuer.yaml
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: hubble-issuer
-  namespace: kube-system
-spec:
-  ca:
-    secretName: hubble-ca-secret
 ---
 # Source: cilium/templates/hubble-relay/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1

--- a/katalog/cilium/hubble/kustomization.yaml
+++ b/katalog/cilium/hubble/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ../core
   - deploy.yaml
   - monitoring
+  - resources/pki.yaml
 
 patchesStrategicMerge:
   - patches/cilium.yaml

--- a/katalog/cilium/hubble/resources/pki.yaml
+++ b/katalog/cilium/hubble/resources/pki.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: hubble-issuer
+  namespace: kube-system
+spec:
+  ca:
+    secretName: hubble-ca-secret
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: self-signed-cilium
+  namespace: kube-system
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hubble-ca-secret
+  namespace: kube-system
+spec:
+  secretName: hubble-ca-secret
+  isCA: true
+  duration: 87600h # 10 years
+  issuerRef:
+    name: self-signed-cilium
+    kind: Issuer
+  commonName: "cilium-ca"
+---
+


### PR DESCRIPTION
### Summary 💡

- **Extract the custom resources for Cilium's PKI (Issuers, CA Certificate) to a separated Kustomize resource** because they are not included in upstream's manifests and to avoid confusion while maintaining the package.
- **Extend the default expiration of the CA certificate to 10 years** to avoid mTLS problems when the sign certificates are still valid but the CA ones have expired.
- Improve maintenance guide
- Add files generated when running the maintenance guide to `.gitignore`

Fixes https://github.com/sighupio/fury-kubernetes-networking/issues/86

### Description 📝

The main gole of this PR is to change the duration of the (custom) self-signed CA certificates from the default 90 days to 10 years to avoid mTLS issues between Cilium components.

tl;dr: certificates mTLS have a duration of 3 years and are signed by the custom CA that has certificates with a 3 months duration. When the components check the certificates after 3 months they find that even though the server and client certificates are valid, the certificate for the CA that signed them has expired.

See the linked issue #86 for more details on the issue.

Note that changing the duration, like we are doing with this change, automatically triggers the renewal of the certificates and we don't need to manually do it:
https://cert-manager.io/docs/usage/certificate/#reissuance-triggered-by-user-actions

> [!IMPORTANT]
> This fixes the root cause of the issue. For already existing installations of KFD the fix requires some additional steps, i.e. manually triggering the renewal of the certificates signed by the expired CA.
> See the [future work](#future-work-) section for more details.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] changed the duration of the CA certificates to "1 hour" and replicated the issue
- [x] applied this change to a KFD v1.31.0 cluster and checked that the Certficate duration gets applied and that the certificate gets renewed.

### Future work 🔧

Distribution-wise we should trigger a certificate renew for the already signed certificates (`hubble-relay-client-certs` and `hubble-server-certs`) to use the new CA certs after patching the duration probably with a post-distribution script; but this would need the usage of the cmctl CLI that is not currently bundled with furyctl.

Note: hubble-relay and cilium will detect the changes in the certificates automatically after the renewal, there's no need to restart them.
