### PR TITLE
Feat: update calico to add experimental compatibility 1.32

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -386,12 +386,93 @@ volumes:
     host:
       path: /var/run/docker.sock
 ---
-name: e2e-kubernetes-1.28-cilium
+name: e2e-kubernetes-1.32-tigera-operator
 kind: pipeline
 type: docker
 
 depends_on:
   - e2e-kubernetes-1.31-tigera-operator
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+
+steps:
+  - name: create Kind cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.27.0_1.32.2_5.6.0
+    pull: always
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_VERSION: v1.31.1
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      # /drone/src is the default workdir for the pipeline
+      # using this folder we don't need to mount another
+      # shared volume between the steps
+      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+    commands:
+      # create a custom config to disable Kind's default CNI so
+      # we can test using KFD's networking module.
+      - |
+        cat <<EOF > kind-config.yaml
+        kind: Cluster
+        apiVersion: kind.x-k8s.io/v1alpha4
+        networking:
+          disableDefaultCNI: true
+        EOF
+      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
+      # does not work when disabling the default CNI. It will always go in timeout.
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config kind-config.yaml
+      # save the kubeconfig so we can use it from other steps.
+      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
+
+  - name: e2e
+    # KUBECTL 1.27.1 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
+    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
+    pull: always
+    network_mode: host
+    environment:
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+      FURYCTL_VERSION: v0.28.0
+    depends_on: [create Kind cluster]
+    commands:
+      - bats -t katalog/tests/calico/tigera.sh
+
+  - name: delete-kind-cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.27.0_1.32.2_5.6.0
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+    commands:
+      # does not matter if the command fails
+      - kind delete cluster --name $${CLUSTER_NAME} || true
+    depends_on:
+      - e2e
+    when:
+      status:
+        - success
+        - failure
+
+volumes:
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
+---
+name: e2e-kubernetes-1.28-cilium
+kind: pipeline
+type: docker
+
+depends_on:
+  - e2e-kubernetes-1.32-tigera-operator
 
 platform:
   os: linux
@@ -727,6 +808,7 @@ depends_on:
   - e2e-kubernetes-1.29-tigera-operator
   - e2e-kubernetes-1.30-tigera-operator
   - e2e-kubernetes-1.31-tigera-operator
+  - e2e-kubernetes-1.32-tigera-operator
   - e2e-kubernetes-1.28-cilium
   - e2e-kubernetes-1.29-cilium
   - e2e-kubernetes-1.30-cilium

--- a/.drone.yml
+++ b/.drone.yml
@@ -61,95 +61,15 @@ steps:
       - render
     commands:
       # we use --ignore-deprecations because we don't want the CI to fail when the API has not been removed yet.
-      - /pluto detect cilium.yml --ignore-deprecations --target-versions=k8s=v1.31.0
-      - /pluto detect tigera-on-prem.yml --ignore-deprecations --target-versions=k8s=v1.31.0
----
-name: e2e-kubernetes-1.28-tigera-operator
-kind: pipeline
-type: docker
-
-depends_on:
-  - policeman
-
-platform:
-  os: linux
-  arch: amd64
-
-trigger:
-  ref:
-    include:
-      - refs/tags/**
-
-steps:
-  - name: create Kind cluster
-    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.24.0_1.29.1_3.10.0
-    pull: always
-    volumes:
-      - name: dockersock
-        path: /var/run/docker.sock
-    environment:
-      CLUSTER_VERSION: v1.28.13
-      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
-      # /drone/src is the default workdir for the pipeline
-      # using this folder we don't need to mount another
-      # shared volume between the steps
-      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
-    commands:
-      # create a custom config to disable Kind's default CNI so
-      # we can test using KFD's networking module.
-      - |
-        cat <<EOF > kind-config.yaml
-        kind: Cluster
-        apiVersion: kind.x-k8s.io/v1alpha4
-        networking:
-          disableDefaultCNI: true
-        EOF
-      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
-      # does not work when disabling the default CNI. It will always go in timeout.
-      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config kind-config.yaml
-      # save the kubeconfig so we can use it from other steps.
-      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
-
-  - name: e2e
-    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
-    pull: always
-    network_mode: host
-    environment:
-      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
-      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
-      FURYCTL_VERSION: v0.28.0
-    depends_on: [create Kind cluster]
-    commands:
-      - bats -t katalog/tests/calico/tigera.sh
-
-  - name: delete-kind-cluster
-    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.24.0_1.29.1_3.10.0
-    volumes:
-      - name: dockersock
-        path: /var/run/docker.sock
-    environment:
-      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
-    commands:
-      # does not matter if the command fails
-      - kind delete cluster --name $${CLUSTER_NAME} || true
-    depends_on:
-      - e2e
-    when:
-      status:
-        - success
-        - failure
-
-volumes:
-  - name: dockersock
-    host:
-      path: /var/run/docker.sock
+      - /pluto detect cilium.yml --ignore-deprecations --target-versions=k8s=v1.32.0
+      - /pluto detect tigera-on-prem.yml --ignore-deprecations --target-versions=k8s=v1.32.0
 ---
 name: e2e-kubernetes-1.29-tigera-operator
 kind: pipeline
 type: docker
 
 depends_on:
-  - e2e-kubernetes-1.28-tigera-operator
+  - policeman
 
 platform:
   os: linux
@@ -408,7 +328,7 @@ steps:
       - name: dockersock
         path: /var/run/docker.sock
     environment:
-      CLUSTER_VERSION: v1.31.1
+      CLUSTER_VERSION: v1.32.2
       CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       # /drone/src is the default workdir for the pipeline
       # using this folder we don't need to mount another
@@ -464,95 +384,12 @@ volumes:
     host:
       path: /var/run/docker.sock
 ---
-name: e2e-kubernetes-1.28-cilium
-kind: pipeline
-type: docker
-
-depends_on:
-  - e2e-kubernetes-1.32-tigera-operator
-
-platform:
-  os: linux
-  arch: amd64
-
-trigger:
-  ref:
-    include:
-      - refs/tags/**
-
-steps:
-  - name: create Kind cluster
-    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.24.0_1.29.1_3.10.0
-    pull: always
-    volumes:
-      - name: dockersock
-        path: /var/run/docker.sock
-    environment:
-      CLUSTER_VERSION: v1.28.13
-      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
-      # /drone/src is the default workdir for the pipeline
-      # using this folder we don't need to mount another
-      # shared volume between the steps
-      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
-    commands:
-      # create a custom config to disable Kind's default CNI so
-      # we can test using KFD's networking module.
-      - |
-        cat <<EOF > kind-config.yaml
-        kind: Cluster
-        apiVersion: kind.x-k8s.io/v1alpha4
-        networking:
-          disableDefaultCNI: true
-        nodes:
-        - role: control-plane
-        - role: worker
-        EOF
-      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
-      # does not work when disabling the default CNI. It will always go in timeout.
-      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config kind-config.yaml
-      # save the kubeconfig so we can use it from other steps.
-      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
-
-  - name: e2e
-    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
-    pull: always
-    network_mode: host
-    environment:
-      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
-      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
-      FURYCTL_VERSION: v0.28.0
-    depends_on: [create Kind cluster]
-    commands:
-      - bats -t katalog/tests/cilium/cilium.sh
-
-  - name: delete-kind-cluster
-    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.24.0_1.29.1_3.10.0
-    volumes:
-      - name: dockersock
-        path: /var/run/docker.sock
-    environment:
-      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
-    commands:
-      # does not matter if the command fails
-      - kind delete cluster --name $${CLUSTER_NAME} || true
-    depends_on:
-      - e2e
-    when:
-      status:
-        - success
-        - failure
-
-volumes:
-  - name: dockersock
-    host:
-      path: /var/run/docker.sock
----
 name: e2e-kubernetes-1.29-cilium
 kind: pipeline
 type: docker
 
 depends_on:
-  - e2e-kubernetes-1.28-cilium
+  - policeman
 
 platform:
   os: linux
@@ -796,20 +633,102 @@ volumes:
     host:
       path: /var/run/docker.sock
 ---
+name: e2e-kubernetes-1.32-cilium
+kind: pipeline
+type: docker
+
+depends_on:
+  - e2e-kubernetes-1.31-cilium
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+
+steps:
+  - name: create Kind cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.27.0_1.32.2_5.6.0
+    pull: always
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_VERSION: v1.32.2
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      # /drone/src is the default workdir for the pipeline
+      # using this folder we don't need to mount another
+      # shared volume between the steps
+      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+    commands:
+      # create a custom config to disable Kind's default CNI so
+      # we can test using KFD's networking module.
+      - |
+        cat <<EOF > kind-config.yaml
+        kind: Cluster
+        apiVersion: kind.x-k8s.io/v1alpha4
+        networking:
+          disableDefaultCNI: true
+        nodes:
+        - role: control-plane
+        - role: worker
+        EOF
+      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
+      # does not work when disabling the default CNI. It will always go in timeout.
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config kind-config.yaml
+      # save the kubeconfig so we can use it from other steps.
+      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
+
+  - name: e2e
+    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
+    pull: always
+    network_mode: host
+    environment:
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+      FURYCTL_VERSION: v0.28.0
+    depends_on: [create Kind cluster]
+    commands:
+      - bats -t katalog/tests/cilium/cilium.sh
+
+  - name: delete-kind-cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.27.0_1.32.2_5.6.0
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+    commands:
+      # does not matter if the command fails
+      - kind delete cluster --name $${CLUSTER_NAME} || true
+    depends_on:
+      - e2e
+    when:
+      status:
+        - success
+        - failure
+
+volumes:
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
+---
 name: release
 kind: pipeline
 type: docker
 
 depends_on:
-  - e2e-kubernetes-1.28-tigera-operator
   - e2e-kubernetes-1.29-tigera-operator
   - e2e-kubernetes-1.30-tigera-operator
   - e2e-kubernetes-1.31-tigera-operator
   - e2e-kubernetes-1.32-tigera-operator
-  - e2e-kubernetes-1.28-cilium
   - e2e-kubernetes-1.29-cilium
   - e2e-kubernetes-1.30-cilium
   - e2e-kubernetes-1.31-cilium
+  - e2e-kubernetes-1.32-cilium
 
 platform:
   os: linux

--- a/.drone.yml
+++ b/.drone.yml
@@ -46,7 +46,7 @@ steps:
       - clone
 
   - name: render
-    image: quay.io/sighup/e2e-testing:1.1.0_3.12.0_1.31.1_3.10.0_4.33.3
+    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
     pull: always
     depends_on:
       - clone
@@ -111,7 +111,7 @@ steps:
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
   - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_1.29.1_3.10.0_4.33.3
+    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
     pull: always
     network_mode: host
     environment:
@@ -191,7 +191,7 @@ steps:
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
   - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_1.29.1_3.10.0_4.33.3
+    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
     pull: always
     network_mode: host
     environment:
@@ -271,8 +271,7 @@ steps:
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
   - name: e2e
-    # KUBECTL 1.27.1 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
-    image: quay.io/sighup/e2e-testing:1.1.0_3.12.0_1.30.5_3.10.0_4.33.3
+    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
     pull: always
     network_mode: host
     environment:
@@ -352,8 +351,7 @@ steps:
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
   - name: e2e
-    # KUBECTL 1.27.1 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
-    image: quay.io/sighup/e2e-testing:1.1.0_3.12.0_1.31.1_3.10.0_4.33.3
+    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
     pull: always
     network_mode: host
     environment:
@@ -433,7 +431,6 @@ steps:
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
   - name: e2e
-    # KUBECTL 1.27.1 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
     image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
     pull: always
     network_mode: host
@@ -517,7 +514,7 @@ steps:
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
   - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_1.29.1_3.10.0_4.33.3
+    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
     pull: always
     network_mode: host
     environment:
@@ -600,7 +597,7 @@ steps:
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
   - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_1.29.1_3.10.0_4.33.3
+    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
     pull: always
     network_mode: host
     environment:
@@ -683,7 +680,7 @@ steps:
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
   - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_3.12.0_1.30.5_3.10.0_4.33.3
+    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
     pull: always
     network_mode: host
     environment:
@@ -766,7 +763,7 @@ steps:
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
   - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_3.12.0_1.31.1_3.10.0_4.33.3
+    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
     pull: always
     network_mode: host
     environment:

--- a/.drone.yml
+++ b/.drone.yml
@@ -841,7 +841,7 @@ steps:
     when:
       ref:
         include:
-          - refs/tags/**
+          - refs/tags/v**
 
   - name: publish-prerelease
     image: plugins/github-release

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -1,17 +1,19 @@
 # Compatibility Matrix
 
-| Module Version / Kubernetes Version | 1.24.X             | 1.25.X             | 1.26.X             | 1.27.X             | 1.28.X             | 1.29.X             | 1.30.X             | 1.31.X             |
-| ----------------------------------- | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
-| v1.10.0                             | :white_check_mark: |                    |                    |                    |                    |                    |                    |                    |
-| v1.11.0                             | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |
-| v1.12.0                             | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |
-| v1.12.1                             | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |
-| v1.12.2                             | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |
-| v1.14.0                             | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |
-| v1.15.0                             |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
-| v1.16.0                             |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |
-| v1.17.0                             |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |
-| v2.0.0                              |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Module Version / Kubernetes Version | 1.24.X             | 1.25.X             | 1.26.X             | 1.27.X             | 1.28.X             | 1.29.X             | 1.30.X             | 1.31.X             | 1.32.X                            |
+| ----------------------------------- | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | --------------------------------- |
+| v1.10.0                             | :white_check_mark: |                    |                    |                    |                    |                    |                    |                    |                                   |
+| v1.11.0                             | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |                                   |
+| v1.12.0                             | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |                                   |
+| v1.12.1                             | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |                                   |
+| v1.12.2                             | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |                                   |
+| v1.14.0                             | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                                   |
+| v1.15.0                             |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                                   |
+| v1.16.0                             |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                                   |
+| v1.17.0                             |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                                   |
+| v2.0.0                              |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                                   |
+| vTBD                                |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: (tech preview) |
+
 
 :white_check_mark: Compatible
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -12,7 +12,7 @@ Welcome to the latest release of the `Networking` module of [`Kubernetes Fury Di
 | ----------------- | -------------------------------------------------------------------------------- | ---------------- |
 | `cilium`          | [`v1.16.3`](https://github.com/cilium/cilium/releases/tag/v1.15.2)               | No update        |
 | `ip-masq`         | [`v2.8.0`](https://github.com/kubernetes-sigs/ip-masq-agent/releases/tag/v2.8.0) | No update        |
-| `tigera-operator` | [`v1.36.1`](https://github.com/tigera/operator/releases/tag/v1.36.1)             | No update        |
+| `tigera-operator` | [`v1.36.5`](https://github.com/tigera/operator/releases/tag/v1.36.5)             | v1.36.1          |
 
 > Please refer the individual release notes to get detailed information on each release.
 

--- a/katalog/tests/calico/resources/echo-server.yaml
+++ b/katalog/tests/calico/resources/echo-server.yaml
@@ -18,7 +18,7 @@ spec:
         app: echoserver
     spec:
       containers:
-      - image: registry.sighup.io/fury/google_containers/echoserver:1.0
+      - image: registry.sighup.io/fury/google_containers/echoserver:1.10
         imagePullPolicy: Always
         name: echoserver
         ports:

--- a/katalog/tigera/MAINTENANCE.md
+++ b/katalog/tigera/MAINTENANCE.md
@@ -11,7 +11,7 @@ To update the YAML file, run the following command:
 
 ```bash
 # assuming katalog/tigera is the root of the repository
-export CALICO_VERSION="3.29.0"
+export CALICO_VERSION="3.29.2"
 curl "https://raw.githubusercontent.com/projectcalico/calico/v${CALICO_VERSION}/manifests/tigera-operator.yaml" --output operator/tigera-operator.yaml
 ```
 
@@ -28,7 +28,7 @@ To download the default configuration from upstream and update the file use the 
 
 ```bash
 # assuming katalog/tigera is the root of the repository
-export CALICO_VERSION="3.29.0"
+export CALICO_VERSION="3.29.2"
 curl https://raw.githubusercontent.com/projectcalico/calico/v${CALICO_VERSION}/manifests/custom-resources.yaml --output on-prem/custom-resources.yaml
 ```
 
@@ -50,7 +50,7 @@ To get the dashboards you can use the following commands:
 
 ```bash
 # ⚠️ Assuming $PWD == root of the project
-export CALICO_VERSION="3.29.0"
+export CALICO_VERSION="3.29.2"
 # we split the upstream file and store only the json files
 curl -L https://raw.githubusercontent.com/projectcalico/calico/v${CALICO_VERSION}/manifests/grafana-dashboards.yaml | yq '.data["felix-dashboard.json"]' | sed 's/calico-demo-prometheus/prometheus/g' | jq > ./on-prem/monitoring/dashboards/felix-dashboard.json
 curl -L https://raw.githubusercontent.com/projectcalico/calico/v${CALICO_VERSION}/manifests/grafana-dashboards.yaml | yq '.data["typha-dashboard.json"]' | sed 's/calico-demo-prometheus/prometheus/g' | jq > ./on-prem/monitoring/dashboards/typa-dashboard.json

--- a/katalog/tigera/on-prem/kustomization.yaml
+++ b/katalog/tigera/on-prem/kustomization.yaml
@@ -10,5 +10,5 @@ resources:
   - custom-resources.yaml
   - monitoring
 
-patchesStrategicMerge:
-  - monitoring/metrics.yaml
+patches:
+  - path: monitoring/metrics.yaml

--- a/katalog/tigera/operator/dummy-dictionary-calico-images.yaml
+++ b/katalog/tigera/operator/dummy-dictionary-calico-images.yaml
@@ -22,19 +22,19 @@ spec:
     spec:
       containers:
         - name: image1
-          image: registry.sighup.io/fury/calico/kube-controllers:v3.29.0
+          image: registry.sighup.io/fury/calico/kube-controllers:v3.29.2
         - name: image2
-          image: registry.sighup.io/fury/calico/cni:v3.29.0
+          image: registry.sighup.io/fury/calico/cni:v3.29.2
         - name: image3
-          image: registry.sighup.io/fury/calico/pod2daemon-flexvol:v3.29.0
+          image: registry.sighup.io/fury/calico/pod2daemon-flexvol:v3.29.2
         - name: image4
-          image: registry.sighup.io/fury/calico/node:v3.29.0
+          image: registry.sighup.io/fury/calico/node:v3.29.2
         - name: image5
-          image: registry.sighup.io/fury/calico/apiserver:v3.29.0
+          image: registry.sighup.io/fury/calico/apiserver:v3.29.2
         - name: image6
-          image: registry.sighup.io/fury/calico/typha:v3.29.0
+          image: registry.sighup.io/fury/calico/typha:v3.29.2
         - name: image7
-          image: registry.sighup.io/fury/calico/csi:v3.29.0
+          image: registry.sighup.io/fury/calico/csi:v3.29.2
         - name: image8
-          image: registry.sighup.io/fury/calico/node-driver-registrar:v3.29.0
+          image: registry.sighup.io/fury/calico/node-driver-registrar:v3.29.2
           

--- a/katalog/tigera/operator/tigera-operator.yaml
+++ b/katalog/tigera/operator/tigera-operator.yaml
@@ -112,8 +112,14 @@ spec:
                           a valid secret key.
                         type: string
                       name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        default: ""
+                        description: 'Name of the referent. This field is effectively
+                          required, but due to backwards compatibility is allowed
+                          to be empty. Instances of this type with an empty value
+                          here are almost certainly wrong. TODO: Add other useful
+                          fields. apiVersion, kind, uid? More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Drop `kubebuilder:default` when controller-gen doesn''t
+                          need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.'
                         type: string
                       optional:
                         description: Specify whether the Secret or its key must be
@@ -464,8 +470,14 @@ spec:
                           a valid secret key.
                         type: string
                       name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        default: ""
+                        description: 'Name of the referent. This field is effectively
+                          required, but due to backwards compatibility is allowed
+                          to be empty. Instances of this type with an empty value
+                          here are almost certainly wrong. TODO: Add other useful
+                          fields. apiVersion, kind, uid? More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Drop `kubebuilder:default` when controller-gen doesn''t
+                          need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.'
                         type: string
                       optional:
                         description: Specify whether the Secret or its key must be
@@ -1865,6 +1877,10 @@ spec:
                 description: 'WireguardRoutingRulePriority controls the priority value
                   to use for the Wireguard routing rule. [Default: 99]'
                 type: integer
+              wireguardThreadingEnabled:
+                description: 'WireguardThreadingEnabled controls whether Wireguard
+                  has NAPI threading enabled. [Default: false]'
+                type: boolean
               workloadSourceSpoofing:
                 description: WorkloadSourceSpoofing controls whether pods can use
                   the allowedSourcePrefixes annotation to send traffic with a source
@@ -7165,6 +7181,21 @@ spec:
             description: Specification of the desired state for the Calico or Calico
               Enterprise installation.
             properties:
+              azure:
+                description: Azure is used to configure azure provider specific options.
+                properties:
+                  policyMode:
+                    default: Default
+                    description: |-
+                      PolicyMode determines whether the "control-plane" label is applied to namespaces. It offers two options: Default and Manual.
+                      The Default option adds the "control-plane" label to the required namespaces.
+                      The Manual option does not apply the "control-plane" label to any namespace.
+                      Default: Default
+                    enum:
+                    - Default
+                    - Manual
+                    type: string
+                type: object
               calicoKubeControllersDeployment:
                 description: |-
                   CalicoKubeControllersDeployment configures the calico-kube-controllers Deployment. If used in
@@ -14534,6 +14565,22 @@ spec:
                 description: Computed is the final installation including overlaid
                   resources.
                 properties:
+                  azure:
+                    description: Azure is used to configure azure provider specific
+                      options.
+                    properties:
+                      policyMode:
+                        default: Default
+                        description: |-
+                          PolicyMode determines whether the "control-plane" label is applied to namespaces. It offers two options: Default and Manual.
+                          The Default option adds the "control-plane" label to the required namespaces.
+                          The Manual option does not apply the "control-plane" label to any namespace.
+                          Default: Default
+                        enum:
+                        - Default
+                        - Manual
+                        type: string
+                    type: object
                   calicoKubeControllersDeployment:
                     description: |-
                       CalicoKubeControllersDeployment configures the calico-kube-controllers Deployment. If used in
@@ -22583,7 +22630,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: tigera-operator
-          image: quay.io/tigera/operator:v1.36.0
+          image: quay.io/tigera/operator:v1.36.5
           imagePullPolicy: IfNotPresent
           command:
             - operator
@@ -22601,7 +22648,7 @@ spec:
             - name: OPERATOR_NAME
               value: "tigera-operator"
             - name: TIGERA_OPERATOR_INIT_IMAGE_VERSION
-              value: v1.36.0
+              value: v1.36.5
           envFrom:
             - configMapRef:
                 name: kubernetes-services-endpoint


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request.
By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull
request to the best possible team for review.

💡 **TIP**
Remember that you can always open a PR in draft status and fill all the information afterwards.

Opening a PR in draft allows other team members to knwo that you are working on this change, and let's you have a 
place to track your work in progress.

When opening PRs in Draft, don't assign reviewers until the PR is ready for review.  Once you are confortable with the
status of the PR and all the tests and CI is green, you can assign the reviewers to start the review process.
-->

### Summary 💡

This PR updates calico to the latest patch, and tests calico against Kubernetes 1.32. Kubernetes 1.32 is marked as a tech preview version in the compatibility matrix

Closes: https://github.com/sighupio/product-management/issues/562

* Update docs
 *Updated kustomize projects to use v5-compatible features

### Breaking Changes 💔

There are no breaking changes.

### Tests performed 🧪

- [x] Tested a clean OnPremises installation with Kubernetes 1.32 and Calico as CNI
