### PR TITLE
Feat: update cilium to 1.17.2

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -386,12 +386,93 @@ volumes:
     host:
       path: /var/run/docker.sock
 ---
-name: e2e-kubernetes-1.28-cilium
+name: e2e-kubernetes-1.32-tigera-operator
 kind: pipeline
 type: docker
 
 depends_on:
   - e2e-kubernetes-1.31-tigera-operator
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+
+steps:
+  - name: create Kind cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.27.0_1.32.2_5.6.0
+    pull: always
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_VERSION: v1.31.1
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      # /drone/src is the default workdir for the pipeline
+      # using this folder we don't need to mount another
+      # shared volume between the steps
+      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+    commands:
+      # create a custom config to disable Kind's default CNI so
+      # we can test using KFD's networking module.
+      - |
+        cat <<EOF > kind-config.yaml
+        kind: Cluster
+        apiVersion: kind.x-k8s.io/v1alpha4
+        networking:
+          disableDefaultCNI: true
+        EOF
+      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
+      # does not work when disabling the default CNI. It will always go in timeout.
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config kind-config.yaml
+      # save the kubeconfig so we can use it from other steps.
+      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
+
+  - name: e2e
+    # KUBECTL 1.27.1 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
+    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
+    pull: always
+    network_mode: host
+    environment:
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+      FURYCTL_VERSION: v0.28.0
+    depends_on: [create Kind cluster]
+    commands:
+      - bats -t katalog/tests/calico/tigera.sh
+
+  - name: delete-kind-cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.27.0_1.32.2_5.6.0
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+    commands:
+      # does not matter if the command fails
+      - kind delete cluster --name $${CLUSTER_NAME} || true
+    depends_on:
+      - e2e
+    when:
+      status:
+        - success
+        - failure
+
+volumes:
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
+---
+name: e2e-kubernetes-1.28-cilium
+kind: pipeline
+type: docker
+
+depends_on:
+  - e2e-kubernetes-1.32-tigera-operator
 
 platform:
   os: linux
@@ -727,6 +808,7 @@ depends_on:
   - e2e-kubernetes-1.29-tigera-operator
   - e2e-kubernetes-1.30-tigera-operator
   - e2e-kubernetes-1.31-tigera-operator
+  - e2e-kubernetes-1.32-tigera-operator
   - e2e-kubernetes-1.28-cilium
   - e2e-kubernetes-1.29-cilium
   - e2e-kubernetes-1.30-cilium

--- a/.drone.yml
+++ b/.drone.yml
@@ -61,95 +61,15 @@ steps:
       - render
     commands:
       # we use --ignore-deprecations because we don't want the CI to fail when the API has not been removed yet.
-      - /pluto detect cilium.yml --ignore-deprecations --target-versions=k8s=v1.31.0
-      - /pluto detect tigera-on-prem.yml --ignore-deprecations --target-versions=k8s=v1.31.0
----
-name: e2e-kubernetes-1.28-tigera-operator
-kind: pipeline
-type: docker
-
-depends_on:
-  - policeman
-
-platform:
-  os: linux
-  arch: amd64
-
-trigger:
-  ref:
-    include:
-      - refs/tags/**
-
-steps:
-  - name: create Kind cluster
-    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.24.0_1.29.1_3.10.0
-    pull: always
-    volumes:
-      - name: dockersock
-        path: /var/run/docker.sock
-    environment:
-      CLUSTER_VERSION: v1.28.13
-      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
-      # /drone/src is the default workdir for the pipeline
-      # using this folder we don't need to mount another
-      # shared volume between the steps
-      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
-    commands:
-      # create a custom config to disable Kind's default CNI so
-      # we can test using KFD's networking module.
-      - |
-        cat <<EOF > kind-config.yaml
-        kind: Cluster
-        apiVersion: kind.x-k8s.io/v1alpha4
-        networking:
-          disableDefaultCNI: true
-        EOF
-      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
-      # does not work when disabling the default CNI. It will always go in timeout.
-      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config kind-config.yaml
-      # save the kubeconfig so we can use it from other steps.
-      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
-
-  - name: e2e
-    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
-    pull: always
-    network_mode: host
-    environment:
-      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
-      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
-      FURYCTL_VERSION: v0.28.0
-    depends_on: [create Kind cluster]
-    commands:
-      - bats -t katalog/tests/calico/tigera.sh
-
-  - name: delete-kind-cluster
-    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.24.0_1.29.1_3.10.0
-    volumes:
-      - name: dockersock
-        path: /var/run/docker.sock
-    environment:
-      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
-    commands:
-      # does not matter if the command fails
-      - kind delete cluster --name $${CLUSTER_NAME} || true
-    depends_on:
-      - e2e
-    when:
-      status:
-        - success
-        - failure
-
-volumes:
-  - name: dockersock
-    host:
-      path: /var/run/docker.sock
+      - /pluto detect cilium.yml --ignore-deprecations --target-versions=k8s=v1.32.0
+      - /pluto detect tigera-on-prem.yml --ignore-deprecations --target-versions=k8s=v1.32.0
 ---
 name: e2e-kubernetes-1.29-tigera-operator
 kind: pipeline
 type: docker
 
 depends_on:
-  - e2e-kubernetes-1.28-tigera-operator
+  - policeman
 
 platform:
   os: linux
@@ -408,7 +328,7 @@ steps:
       - name: dockersock
         path: /var/run/docker.sock
     environment:
-      CLUSTER_VERSION: v1.31.1
+      CLUSTER_VERSION: v1.32.2
       CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       # /drone/src is the default workdir for the pipeline
       # using this folder we don't need to mount another
@@ -464,95 +384,12 @@ volumes:
     host:
       path: /var/run/docker.sock
 ---
-name: e2e-kubernetes-1.28-cilium
-kind: pipeline
-type: docker
-
-depends_on:
-  - e2e-kubernetes-1.32-tigera-operator
-
-platform:
-  os: linux
-  arch: amd64
-
-trigger:
-  ref:
-    include:
-      - refs/tags/**
-
-steps:
-  - name: create Kind cluster
-    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.24.0_1.29.1_3.10.0
-    pull: always
-    volumes:
-      - name: dockersock
-        path: /var/run/docker.sock
-    environment:
-      CLUSTER_VERSION: v1.28.13
-      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
-      # /drone/src is the default workdir for the pipeline
-      # using this folder we don't need to mount another
-      # shared volume between the steps
-      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
-    commands:
-      # create a custom config to disable Kind's default CNI so
-      # we can test using KFD's networking module.
-      - |
-        cat <<EOF > kind-config.yaml
-        kind: Cluster
-        apiVersion: kind.x-k8s.io/v1alpha4
-        networking:
-          disableDefaultCNI: true
-        nodes:
-        - role: control-plane
-        - role: worker
-        EOF
-      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
-      # does not work when disabling the default CNI. It will always go in timeout.
-      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config kind-config.yaml
-      # save the kubeconfig so we can use it from other steps.
-      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
-
-  - name: e2e
-    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
-    pull: always
-    network_mode: host
-    environment:
-      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
-      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
-      FURYCTL_VERSION: v0.28.0
-    depends_on: [create Kind cluster]
-    commands:
-      - bats -t katalog/tests/cilium/cilium.sh
-
-  - name: delete-kind-cluster
-    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.24.0_1.29.1_3.10.0
-    volumes:
-      - name: dockersock
-        path: /var/run/docker.sock
-    environment:
-      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
-    commands:
-      # does not matter if the command fails
-      - kind delete cluster --name $${CLUSTER_NAME} || true
-    depends_on:
-      - e2e
-    when:
-      status:
-        - success
-        - failure
-
-volumes:
-  - name: dockersock
-    host:
-      path: /var/run/docker.sock
----
 name: e2e-kubernetes-1.29-cilium
 kind: pipeline
 type: docker
 
 depends_on:
-  - e2e-kubernetes-1.28-cilium
+  - policeman
 
 platform:
   os: linux
@@ -796,20 +633,102 @@ volumes:
     host:
       path: /var/run/docker.sock
 ---
+name: e2e-kubernetes-1.32-cilium
+kind: pipeline
+type: docker
+
+depends_on:
+  - e2e-kubernetes-1.31-cilium
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+
+steps:
+  - name: create Kind cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.27.0_1.32.2_5.6.0
+    pull: always
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_VERSION: v1.32.2
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      # /drone/src is the default workdir for the pipeline
+      # using this folder we don't need to mount another
+      # shared volume between the steps
+      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+    commands:
+      # create a custom config to disable Kind's default CNI so
+      # we can test using KFD's networking module.
+      - |
+        cat <<EOF > kind-config.yaml
+        kind: Cluster
+        apiVersion: kind.x-k8s.io/v1alpha4
+        networking:
+          disableDefaultCNI: true
+        nodes:
+        - role: control-plane
+        - role: worker
+        EOF
+      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
+      # does not work when disabling the default CNI. It will always go in timeout.
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config kind-config.yaml
+      # save the kubeconfig so we can use it from other steps.
+      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
+
+  - name: e2e
+    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
+    pull: always
+    network_mode: host
+    environment:
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+      FURYCTL_VERSION: v0.28.0
+    depends_on: [create Kind cluster]
+    commands:
+      - bats -t katalog/tests/cilium/cilium.sh
+
+  - name: delete-kind-cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.27.0_1.32.2_5.6.0
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_NAME: ${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+    commands:
+      # does not matter if the command fails
+      - kind delete cluster --name $${CLUSTER_NAME} || true
+    depends_on:
+      - e2e
+    when:
+      status:
+        - success
+        - failure
+
+volumes:
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
+---
 name: release
 kind: pipeline
 type: docker
 
 depends_on:
-  - e2e-kubernetes-1.28-tigera-operator
   - e2e-kubernetes-1.29-tigera-operator
   - e2e-kubernetes-1.30-tigera-operator
   - e2e-kubernetes-1.31-tigera-operator
   - e2e-kubernetes-1.32-tigera-operator
-  - e2e-kubernetes-1.28-cilium
   - e2e-kubernetes-1.29-cilium
   - e2e-kubernetes-1.30-cilium
   - e2e-kubernetes-1.31-cilium
+  - e2e-kubernetes-1.32-cilium
 
 platform:
   os: linux

--- a/.drone.yml
+++ b/.drone.yml
@@ -46,7 +46,7 @@ steps:
       - clone
 
   - name: render
-    image: quay.io/sighup/e2e-testing:1.1.0_3.12.0_1.31.1_3.10.0_4.33.3
+    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
     pull: always
     depends_on:
       - clone
@@ -111,7 +111,7 @@ steps:
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
   - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_1.29.1_3.10.0_4.33.3
+    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
     pull: always
     network_mode: host
     environment:
@@ -191,7 +191,7 @@ steps:
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
   - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_1.29.1_3.10.0_4.33.3
+    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
     pull: always
     network_mode: host
     environment:
@@ -271,8 +271,7 @@ steps:
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
   - name: e2e
-    # KUBECTL 1.27.1 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
-    image: quay.io/sighup/e2e-testing:1.1.0_3.12.0_1.30.5_3.10.0_4.33.3
+    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
     pull: always
     network_mode: host
     environment:
@@ -352,8 +351,7 @@ steps:
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
   - name: e2e
-    # KUBECTL 1.27.1 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
-    image: quay.io/sighup/e2e-testing:1.1.0_3.12.0_1.31.1_3.10.0_4.33.3
+    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
     pull: always
     network_mode: host
     environment:
@@ -433,7 +431,6 @@ steps:
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
   - name: e2e
-    # KUBECTL 1.27.1 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
     image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
     pull: always
     network_mode: host
@@ -517,7 +514,7 @@ steps:
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
   - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_1.29.1_3.10.0_4.33.3
+    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
     pull: always
     network_mode: host
     environment:
@@ -600,7 +597,7 @@ steps:
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
   - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_1.29.1_3.10.0_4.33.3
+    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
     pull: always
     network_mode: host
     environment:
@@ -683,7 +680,7 @@ steps:
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
   - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_3.12.0_1.30.5_3.10.0_4.33.3
+    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
     pull: always
     network_mode: host
     environment:
@@ -766,7 +763,7 @@ steps:
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
   - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_3.12.0_1.31.1_3.10.0_4.33.3
+    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
     pull: always
     network_mode: host
     environment:

--- a/.drone.yml
+++ b/.drone.yml
@@ -841,7 +841,7 @@ steps:
     when:
       ref:
         include:
-          - refs/tags/**
+          - refs/tags/v**
 
   - name: publish-prerelease
     image: plugins/github-release

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -1,17 +1,19 @@
 # Compatibility Matrix
 
-| Module Version / Kubernetes Version | 1.24.X             | 1.25.X             | 1.26.X             | 1.27.X             | 1.28.X             | 1.29.X             | 1.30.X             | 1.31.X             |
-| ----------------------------------- | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
-| v1.10.0                             | :white_check_mark: |                    |                    |                    |                    |                    |                    |                    |
-| v1.11.0                             | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |
-| v1.12.0                             | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |
-| v1.12.1                             | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |
-| v1.12.2                             | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |
-| v1.14.0                             | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |
-| v1.15.0                             |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
-| v1.16.0                             |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |
-| v1.17.0                             |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |
-| v2.0.0                              |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Module Version / Kubernetes Version | 1.24.X             | 1.25.X             | 1.26.X             | 1.27.X             | 1.28.X             | 1.29.X             | 1.30.X             | 1.31.X             | 1.32.X                            |
+| ----------------------------------- | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | --------------------------------- |
+| v1.10.0                             | :white_check_mark: |                    |                    |                    |                    |                    |                    |                    |                                   |
+| v1.11.0                             | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |                                   |
+| v1.12.0                             | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |                                   |
+| v1.12.1                             | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |                                   |
+| v1.12.2                             | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |                                   |
+| v1.14.0                             | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                                   |
+| v1.15.0                             |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                                   |
+| v1.16.0                             |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                                   |
+| v1.17.0                             |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                                   |
+| v2.0.0                              |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                                   |
+| vTBD                                |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: (tech preview) |
+
 
 :white_check_mark: Compatible
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -10,7 +10,7 @@ Welcome to the latest release of the `Networking` module of [`Kubernetes Fury Di
 
 | Component         | Supported Version                                                                | Previous Version |
 | ----------------- | -------------------------------------------------------------------------------- | ---------------- |
-| `cilium`          | [`v1.16.3`](https://github.com/cilium/cilium/releases/tag/v1.15.2)               | No update        |
+| `cilium`          | [`v1.17.2`](https://github.com/cilium/cilium/releases/tag/v1.17.2)               | v1.16.3          |
 | `ip-masq`         | [`v2.8.0`](https://github.com/kubernetes-sigs/ip-masq-agent/releases/tag/v2.8.0) | No update        |
 | `tigera-operator` | [`v1.36.5`](https://github.com/tigera/operator/releases/tag/v1.36.5)             | v1.36.1          |
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -12,7 +12,7 @@ Welcome to the latest release of the `Networking` module of [`Kubernetes Fury Di
 | ----------------- | -------------------------------------------------------------------------------- | ---------------- |
 | `cilium`          | [`v1.16.3`](https://github.com/cilium/cilium/releases/tag/v1.15.2)               | No update        |
 | `ip-masq`         | [`v2.8.0`](https://github.com/kubernetes-sigs/ip-masq-agent/releases/tag/v2.8.0) | No update        |
-| `tigera-operator` | [`v1.36.1`](https://github.com/tigera/operator/releases/tag/v1.36.1)             | No update        |
+| `tigera-operator` | [`v1.36.5`](https://github.com/tigera/operator/releases/tag/v1.36.5)             | v1.36.1          |
 
 > Please refer the individual release notes to get detailed information on each release.
 

--- a/katalog/cilium/MAINTENANCE.md
+++ b/katalog/cilium/MAINTENANCE.md
@@ -10,7 +10,7 @@ To update the Cilium package with upstream, please follow the next steps.
 helm repo add cilium https://helm.cilium.io/
 helm repo update
 helm search repo cilium/cilium
-helm pull cilium/cilium --version 1.16.3 --untar --untardir /tmp
+helm pull cilium/cilium --version 1.17.2 --untar --untardir /tmp
 ```
 
 1.2. Compare the `MAINTENANCE.values.yaml` with the one from the chart `/tmp/cilium/values.yaml` and port the changes that are needed. For example, update the image tags and check that parameters that were in use are still valid.

--- a/katalog/cilium/MAINTENANCE.values.yaml
+++ b/katalog/cilium/MAINTENANCE.values.yaml
@@ -7,7 +7,7 @@
 image:
   override: ~
   repository: "registry.sighup.io/fury/cilium/cilium"
-  tag: "v1.16.3"
+  tag: "v1.17.2"
   useDigest: false
 
 # -- Affinity for cilium-agent.
@@ -76,7 +76,7 @@ hubble:
     image:
       override: ~
       repository: "registry.sighup.io/fury/cilium/hubble-relay"
-      tag: "v1.16.3"
+      tag: "v1.17.2"
 
       useDigest: false
       pullPolicy: "IfNotPresent"
@@ -120,7 +120,7 @@ hubble:
       image:
         override: ~
         repository: "registry.sighup.io/fury/cilium/hubble-ui-backend"
-        tag: "v0.13.1"
+        tag: "v0.13.2"
 
         useDigest: false
         pullPolicy: "IfNotPresent"
@@ -138,7 +138,7 @@ hubble:
       image:
         override: ~
         repository: "registry.sighup.io/fury/cilium/hubble-ui"
-        tag: "v0.13.1"
+        tag: "v0.13.2"
         useDigest: false
         pullPolicy: "IfNotPresent"
 
@@ -170,15 +170,26 @@ identityChangeGracePeriod: ""
 # routing and full KPR mode. Moreover, this option cannot be enabled when Cilium
 # is running in a managed Kubernetes environment or in a chained CNI setup.
 installNoConntrackIptablesRules: false
+ipam:
+  mode: "cluster-pool"
+  installUplinkRoutesForDelegatedIPAM: false
+  operator:
+    clusterPoolIPv4PodCIDRList: ["10.0.0.0/8"]
+    clusterPoolIPv4MaskSize: 24
+    clusterPoolIPv6PodCIDRList: ["fd00::/104"]
+    clusterPoolIPv6MaskSize: 120
 
-
+defaultLBServiceIPAM: lbipam
+nodeIPAM:
+  enabled: false
 # -- Configure the eBPF-based ip-masq-agent
 ipMasqAgent:
   enabled: false
-  # the config of nonMasqueradeCIDRs
-  # config:
-  # nonMasqueradeCIDRs: []
-  # masqLinkLocal: false
+# the config of nonMasqueradeCIDRs
+# config:
+#   nonMasqueradeCIDRs: []
+#   masqLinkLocal: false
+#   masqLinkLocalIPv6: false
 
 # iptablesLockTimeout defines the iptables "--wait" option when invoked from Cilium.
 # iptablesLockTimeout: "5s"
@@ -192,14 +203,14 @@ ipv6:
   enabled: false
 
 # -- Configure Kubernetes specific configuration
-k8s: {}
+k8s:
   # -- requireIPv4PodCIDR enables waiting for Kubernetes to provide the PodCIDR
   # range via the Kubernetes node resource
-  # requireIPv4PodCIDR: false
+  requireIPv4PodCIDR: false
 
   # -- requireIPv6PodCIDR enables waiting for Kubernetes to provide the PodCIDR
   # range via the Kubernetes node resource
-# requireIPv6PodCIDR: false
+  requireIPv6PodCIDR: false
 # -- Enable Layer 7 network policy.
 l7Proxy: true
 
@@ -219,6 +230,7 @@ logSystemLoad: false
 
 # -- Configure prometheus metrics on the configured port at /metrics
 prometheus:
+  metricsService: true
   enabled: true
   port: 9962
   serviceMonitor:
@@ -259,7 +271,7 @@ operator:
   image:
     override: ~
     repository: "registry.sighup.io/fury/cilium/operator"
-    tag: "v1.16.3"
+    tag: "v1.17.2"
 
     useDigest: false
     pullPolicy: "IfNotPresent"
@@ -268,6 +280,7 @@ operator:
   # -- Enable prometheus metrics for cilium-operator on the configured port at
   # /metrics
   prometheus:
+    metricsService: true
     enabled: true
     port: 9963
     serviceMonitor:

--- a/katalog/cilium/README.md
+++ b/katalog/cilium/README.md
@@ -15,16 +15,16 @@ Additionally, we deploy hubble component as an observability tool on the network
 ## Image repository and tag
 
 - cilium images:
-  - `registry.sighup.io/fury/cilium/cilium:v1.13.3`
-  - `registry.sighup.io/fury/cilium/operator-generic:v1.13.3`
-  - `registry.sighup.io/fury/cilium/hubble-ui-backend:v0.11.0`
-  - `registry.sighup.io/fury/cilium/hubble-ui:v0.11.0`
-  - `registry.sighup.io/fury/cilium/hubble-relay:v1.13.3`
+  - `registry.sighup.io/fury/cilium/cilium`
+  - `registry.sighup.io/fury/cilium/operator-generic`
+  - `registry.sighup.io/fury/cilium/hubble-ui-backend`
+  - `registry.sighup.io/fury/cilium/hubble-ui`
+  - `registry.sighup.io/fury/cilium/hubble-relay`
 
 ## Requirements
 
-- Kubernetes >= `1.24.X`.
-- Kustomize >= `v3.5.3`.
+- Kubernetes >= `1.29.X`.
+- Kustomize >= `v5.6.0`.
 - [prometheus-operator from KFD monitoring module][prometheus-operator]
 - [cert-manager from KFD ingress module][cert-manager]
 

--- a/katalog/cilium/core/deploy.yaml
+++ b/katalog/cilium/core/deploy.yaml
@@ -2,6 +2,14 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 ---
+# Source: cilium/templates/cilium-secrets-namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "cilium-secrets"
+  labels:
+    app.kubernetes.io/part-of: cilium
+---
 # Source: cilium/templates/cilium-agent/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -25,7 +33,8 @@ metadata:
 data:
 
   # Identity allocation mode selects how identities are shared between cilium
-  # nodes by setting how they are stored. The options are "crd" or "kvstore".
+  # nodes by setting how they are stored. The options are "crd", "kvstore" or
+  # "doublewrite-readkvstore" / "doublewrite-readcrd".
   # - "crd" stores identities in kubernetes as CRDs (custom resource definition).
   #   These can be queried with:
   #     kubectl get ciliumid
@@ -34,12 +43,15 @@ data:
   #   backend. Upgrades from these older cilium versions should continue using
   #   the kvstore by commenting out the identity-allocation-mode below, or
   #   setting it to "kvstore".
+  # - "doublewrite" modes store identities in both the kvstore and CRDs. This is useful
+  #   for seamless migrations from the kvstore mode to the crd mode. Consult the
+  #   documentation for more information on how to perform the migration.
   identity-allocation-mode: crd
+
   identity-heartbeat-timeout: "30m0s"
   identity-gc-interval: "15m0s"
   cilium-endpoint-gc-interval: "5m0s"
   nodes-gc-interval: "5m0s"
-  skip-cnp-status-startup-clean: "false"
 
   # If you want to run cilium in debug mode change this value to true
   debug: "false"
@@ -71,6 +83,9 @@ data:
   # is scheduled.
   operator-prometheus-serve-addr: ":9963"
   enable-metrics: "true"
+  enable-policy-secrets-sync: "true"
+  policy-secrets-only-from-secrets-namespace: "true"
+  policy-secrets-namespace: "cilium-secrets"
 
   # Enable IPv4 addressing. If enabled, all endpoints are allocated an IPv4
   # address.
@@ -109,7 +124,11 @@ data:
   # backend and affinity maps.
   bpf-lb-map-max: "65536"
   bpf-lb-external-clusterip: "false"
+  bpf-lb-source-range-all-types: "false"
+  bpf-lb-algorithm-annotation: "false"
+  bpf-lb-mode-annotation: "false"
 
+  bpf-distributed-lru: "false"
   bpf-events-drop-enabled: "true"
   bpf-events-policy-verdict-enabled: "true"
   bpf-events-trace-enabled: "true"
@@ -131,10 +150,6 @@ data:
   # 1.4 or later, then it may cause one-time disruptions during the upgrade.
   preallocate-bpf-maps: "false"
 
-  # Regular expression matching compatible Istio sidecar istio-proxy
-  # container image names
-  sidecar-istio-proxy-image: "cilium/istio_proxy"
-
   # Name of the cluster. Only relevant when building a mesh of clusters.
   cluster-name: default
   # Unique ID of the cluster. Must be unique across all conneted clusters and
@@ -146,9 +161,10 @@ data:
   #   - disabled
   #   - vxlan (default)
   #   - geneve
-  # Default case
+
   routing-mode: "tunnel"
   tunnel-protocol: "vxlan"
+  tunnel-source-port-range: "0-0"
   service-no-backend-response: "reject"
 
 
@@ -165,6 +181,7 @@ data:
 
   enable-xt-socket-fallback: "true"
   install-no-conntrack-iptables-rules: "false"
+  iptables-random-fully: "false"
 
   auto-direct-node-routes: "false"
   direct-routing-skip-unreachable: "false"
@@ -174,9 +191,6 @@ data:
   kube-proxy-replacement: "false"
   kube-proxy-replacement-healthz-bind-address: ""
   bpf-lb-sock: "false"
-  bpf-lb-sock-terminate-pod-connections: "false"
-  enable-host-port: "false"
-  enable-external-ips: "false"
   enable-node-port: "false"
   nodeport-addresses: ""
   enable-health-check-nodeport: "true"
@@ -184,41 +198,44 @@ data:
   node-port-bind-protection: "true"
   enable-auto-protect-node-port-range: "true"
   bpf-lb-acceleration: "disabled"
+  enable-experimental-lb: "false"
   enable-svc-source-range-check: "true"
   enable-l2-neigh-discovery: "true"
   arping-refresh-period: "30s"
   k8s-require-ipv4-pod-cidr: "false"
   k8s-require-ipv6-pod-cidr: "false"
   enable-k8s-networkpolicy: "true"
+  enable-endpoint-lockdown-on-policy-overflow: "false"
   # Tell the agent to generate and write a CNI configuration file
   write-cni-conf-when-ready: /host/etc/cni/net.d/05-cilium.conflist
   cni-exclusive: "true"
   cni-log-file: "/var/run/cilium/cilium-cni.log"
   enable-endpoint-health-checking: "true"
   enable-health-checking: "true"
+  health-check-icmp-failure-threshold: "3"
   enable-well-known-identities: "false"
-  enable-remote-node-identity: "true"
+  enable-node-selector-labels: "false"
   synchronize-k8s-nodes: "true"
   operator-api-serve-addr: "127.0.0.1:9234"
+
+  enable-hubble: "false"
   ipam: "cluster-pool"
   ipam-cilium-node-update-rate: "15s"
   cluster-pool-ipv4-cidr: "10.0.0.0/8"
   cluster-pool-ipv4-mask-size: "24"
+
+  default-lb-service-ipam: "lbipam"
   egress-gateway-reconciliation-trigger-interval: "1s"
   enable-vtep: "false"
   vtep-endpoint: ""
   vtep-cidr: ""
   vtep-mask: ""
   vtep-mac: ""
-  enable-bgp-control-plane: "false"
   procfs: "/host/proc"
   bpf-root: "/sys/fs/bpf"
   cgroup-root: "/run/cilium/cgroupv2"
   enable-k8s-terminating-endpoint: "true"
   enable-sctp: "false"
-
-  k8s-client-qps: "10"
-  k8s-client-burst: "20"
   remove-cilium-node-taints: "true"
   set-cilium-node-taints: "true"
   set-cilium-is-up-condition: "true"
@@ -228,7 +245,7 @@ data:
   dnsproxy-socket-linger-timeout: "10"
   tofqdns-dns-reject-response-code: "refused"
   tofqdns-enable-dns-compression: "true"
-  tofqdns-endpoint-max-ip-per-hostname: "50"
+  tofqdns-endpoint-max-ip-per-hostname: "1000"
   tofqdns-idle-connection-grace-period: "0s"
   tofqdns-max-deferred-connection-deletes: "10000"
   tofqdns-proxy-response-max-delay: "100ms"
@@ -242,13 +259,16 @@ data:
   proxy-xff-num-trusted-hops-ingress: "0"
   proxy-xff-num-trusted-hops-egress: "0"
   proxy-connect-timeout: "2"
+  proxy-initial-fetch-timeout: "30"
   proxy-max-requests-per-connection: "0"
   proxy-max-connection-duration-seconds: "0"
   proxy-idle-timeout-seconds: "60"
+  proxy-max-concurrent-retries: "128"
+  http-retry-count: "3"
 
-  external-envoy-proxy: "true"
+  external-envoy-proxy: "false"
   envoy-base-id: "0"
-
+  envoy-access-log-buffer-size: "4096"
   envoy-keep-cap-netbindservice: "false"
   max-connected-clusters: "255"
   clustermesh-enable-endpoint-sync: "false"
@@ -256,6 +276,10 @@ data:
 
   nat-map-stats-entries: "32"
   nat-map-stats-interval: "30s"
+  enable-internal-traffic-policy: "true"
+  enable-lb-ipam: "true"
+  enable-non-default-deny-policies: "true"
+  enable-source-ip-verification: "true"
 
 # Extra config allows adding arbitrary properties to the cilium config.
 # By putting it at the end of the ConfigMap, it's also possible to override existing properties.
@@ -365,8 +389,6 @@ rules:
 - apiGroups:
   - cilium.io
   resources:
-  - ciliumnetworkpolicies/status
-  - ciliumclusterwidenetworkpolicies/status
   - ciliumendpoints/status
   - ciliumendpoints
   - ciliuml2announcementpolicies/status
@@ -439,6 +461,7 @@ rules:
   resources:
   # to check apiserver connectivity
   - namespaces
+  - secrets
   verbs:
   - get
   - list
@@ -529,6 +552,13 @@ rules:
   - delete
   - patch
 - apiGroups:
+  - cilium.io
+  resources:
+  - ciliumbgpclusterconfigs/status
+  - ciliumbgppeerconfigs/status
+  verbs:
+  - update
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
@@ -574,6 +604,7 @@ rules:
   - ciliumbgppeeringpolicies
   - ciliumbgpclusterconfigs
   - ciliumbgpnodeconfigoverrides
+  - ciliumbgppeerconfigs
   verbs:
   - get
   - list
@@ -655,6 +686,43 @@ rules:
   - list
   - watch
 ---
+# Source: cilium/templates/cilium-agent/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cilium-tlsinterception-secrets
+  namespace: "cilium-secrets"  
+  labels:
+    app.kubernetes.io/part-of: cilium
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: cilium/templates/cilium-operator/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cilium-operator-tlsinterception-secrets
+  namespace: "cilium-secrets"
+  labels:
+    app.kubernetes.io/part-of: cilium
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - update
+  - patch
+---
 # Source: cilium/templates/cilium-agent/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -671,6 +739,40 @@ subjects:
   - kind: ServiceAccount
     name: "cilium"
     namespace: kube-system
+---
+# Source: cilium/templates/cilium-agent/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cilium-tlsinterception-secrets
+  namespace: "cilium-secrets"
+  labels:
+    app.kubernetes.io/part-of: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-tlsinterception-secrets
+subjects:
+- kind: ServiceAccount
+  name: "cilium"
+  namespace: kube-system
+---
+# Source: cilium/templates/cilium-operator/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cilium-operator-tlsinterception-secrets
+  namespace: "cilium-secrets"
+  labels:
+    app.kubernetes.io/part-of: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-operator-tlsinterception-secrets
+subjects:
+- kind: ServiceAccount
+  name: "cilium-operator"
+  namespace: kube-system
 ---
 # Source: cilium/templates/cilium-agent/service.yaml
 apiVersion: v1
@@ -748,18 +850,14 @@ spec:
         container.apparmor.security.beta.kubernetes.io/clean-cilium-state: "unconfined"
         container.apparmor.security.beta.kubernetes.io/mount-cgroup: "unconfined"
         container.apparmor.security.beta.kubernetes.io/apply-sysctl-overwrites: "unconfined"
-        # NOTE: the value "unconfined" should now be set by the securityContext below
       labels:
         k8s-app: cilium
         app.kubernetes.io/name: cilium-agent
         app.kubernetes.io/part-of: cilium
     spec:
-      # securityContext:
-      #   appArmorProfile:
-      #     type: Unconfined
       containers:
       - name: cilium-agent
-        image: "registry.sighup.io/fury/cilium/cilium:v1.16.3"
+        image: "registry.sighup.io/fury/cilium/cilium:v1.17.2"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-agent
@@ -832,7 +930,7 @@ spec:
                     set -o errexit
                     set -o pipefail
                     set -o nounset
-
+                    
                     # When running in AWS ENI mode, it's likely that 'aws-node' has
                     # had a chance to install SNAT iptables rules. These can result
                     # in dropped traffic, so we should attempt to remove them.
@@ -848,7 +946,7 @@ spec:
                         iptables-save | grep -E -v 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN' | iptables-restore
                     fi
                     echo 'Done!'
-
+                    
           preStop:
             exec:
               command:
@@ -865,6 +963,10 @@ spec:
         - name: envoy-metrics
           containerPort: 9964
           hostPort: 9964
+          protocol: TCP
+        - name: envoy-admin
+          containerPort: 9901
+          hostPort: 9901
           protocol: TCP
         securityContext:
           seLinuxOptions:
@@ -905,6 +1007,9 @@ spec:
           mountPropagation: HostToContainer
         - name: cilium-run
           mountPath: /var/run/cilium
+        - name: cilium-netns
+          mountPath: /var/run/cilium/netns
+          mountPropagation: HostToContainer
         - name: etc-cni-netd
           mountPath: /host/etc/cni/net.d
         - name: clustermesh-secrets
@@ -920,7 +1025,7 @@ spec:
           mountPath: /tmp
       initContainers:
       - name: config
-        image: "registry.sighup.io/fury/cilium/cilium:v1.16.3"
+        image: "registry.sighup.io/fury/cilium/cilium:v1.17.2"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-dbg
@@ -943,7 +1048,7 @@ spec:
       # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
       # We use nsenter command with host's cgroup and mount namespaces enabled.
       - name: mount-cgroup
-        image: "registry.sighup.io/fury/cilium/cilium:v1.16.3"
+        image: "registry.sighup.io/fury/cilium/cilium:v1.17.2"
         imagePullPolicy: IfNotPresent
         env:
         - name: CGROUP_ROOT
@@ -980,7 +1085,7 @@ spec:
             drop:
               - ALL
       - name: apply-sysctl-overwrites
-        image: "registry.sighup.io/fury/cilium/cilium:v1.16.3"
+        image: "registry.sighup.io/fury/cilium/cilium:v1.17.2"
         imagePullPolicy: IfNotPresent
         env:
         - name: BIN_PATH
@@ -1018,7 +1123,7 @@ spec:
       # from a privileged container because the mount propagation bidirectional
       # only works from privileged containers.
       - name: mount-bpf-fs
-        image: "registry.sighup.io/fury/cilium/cilium:v1.16.3"
+        image: "registry.sighup.io/fury/cilium/cilium:v1.17.2"
         imagePullPolicy: IfNotPresent
         args:
         - 'mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf'
@@ -1034,7 +1139,7 @@ spec:
           mountPath: /sys/fs/bpf
           mountPropagation: Bidirectional
       - name: clean-cilium-state
-        image: "registry.sighup.io/fury/cilium/cilium:v1.16.3"
+        image: "registry.sighup.io/fury/cilium/cilium:v1.17.2"
         imagePullPolicy: IfNotPresent
         command:
         - /init-container.sh
@@ -1081,7 +1186,7 @@ spec:
           mountPath: /var/run/cilium # wait-for-kube-proxy
       # Install the CNI binaries in an InitContainer so we don't have a writable host mount in the agent
       - name: install-cni-binaries
-        image: "registry.sighup.io/fury/cilium/cilium:v1.16.3"
+        image: "registry.sighup.io/fury/cilium/cilium:v1.17.2"
         imagePullPolicy: IfNotPresent
         command:
           - "/install-plugin.sh"
@@ -1102,7 +1207,6 @@ spec:
             mountPath: /host/opt/cni/bin # .Values.cni.install
       restartPolicy: Always
       priorityClassName: system-node-critical
-      serviceAccount: "cilium"
       serviceAccountName: "cilium"
       automountServiceAccountToken: true
       terminationGracePeriodSeconds: 1
@@ -1126,6 +1230,11 @@ spec:
       - name: cilium-run
         hostPath:
           path: /var/run/cilium
+          type: DirectoryOrCreate
+        # To exec into pod network namespaces
+      - name: cilium-netns
+        hostPath:
+          path: /var/run/netns
           type: DirectoryOrCreate
         # To keep state between restarts / upgrades for bpf maps
       - name: bpf-maps
@@ -1184,6 +1293,20 @@ spec:
                 path: common-etcd-client.crt
               - key: ca.crt
                 path: common-etcd-client-ca.crt
+          # note: we configure the volume for the kvstoremesh-specific certificate
+          # regardless of whether KVStoreMesh is enabled or not, so that it can be
+          # automatically mounted in case KVStoreMesh gets subsequently enabled,
+          # without requiring an agent restart.
+          - secret:
+              name: clustermesh-apiserver-local-cert
+              optional: true
+              items:
+              - key: tls.key
+                path: local-etcd-client.key
+              - key: tls.crt
+                path: local-etcd-client.crt
+              - key: ca.crt
+                path: local-etcd-client-ca.crt
       - name: host-proc-sys-net
         hostPath:
           path: /proc/sys/net
@@ -1232,7 +1355,7 @@ spec:
     spec:
       containers:
       - name: cilium-operator
-        image: "registry.sighup.io/fury/cilium/operator-generic:v1.16.3"
+        image: "registry.sighup.io/fury/cilium/operator-generic:v1.17.2"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-operator-generic
@@ -1288,7 +1411,6 @@ spec:
       hostNetwork: true
       restartPolicy: Always
       priorityClassName: system-cluster-critical
-      serviceAccount: "cilium-operator"
       serviceAccountName: "cilium-operator"
       automountServiceAccountToken: true
       # In HA mode, cilium-operator pods must not be scheduled on the same
@@ -1321,7 +1443,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      k8s-app: cilium
+      app.kubernetes.io/name: cilium-agent
   namespaceSelector:
     matchNames:
     - kube-system
@@ -1335,6 +1457,8 @@ spec:
       sourceLabels:
       - __meta_kubernetes_pod_node_name
       targetLabel: node
+  # If envoy DaemonSet is enabled, we'll create a separate service for it
+  # If it is not enabled, that means envoy runs inside cilium-agent and we'll monitor using same service
   targetLabels:
   - k8s-app
 ---

--- a/katalog/cilium/core/kustomization.yaml
+++ b/katalog/cilium/core/kustomization.yaml
@@ -5,8 +5,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: kube-system
-
 resources:
   - deploy.yaml
   - monitoring

--- a/katalog/cilium/hubble/deploy.yaml
+++ b/katalog/cilium/hubble/deploy.yaml
@@ -8,6 +8,7 @@ kind: ServiceAccount
 metadata:
   name: hubble-relay
   namespace: kube-system
+automountServiceAccountToken: false
 ---
 # Source: cilium/templates/hubble-ui/serviceaccount.yaml
 apiVersion: v1
@@ -25,18 +26,18 @@ metadata:
 data:
   config.yaml: |
     cluster-name: default
-    peer-service: "hubble-peer.kube-system.svc.cluster.local:443"
+    peer-service: "hubble-peer.kube-system.svc.cluster.local.:443"
     listen-address: :4245
     gops: true
     gops-port: "9893"
     metrics-listen-address: ":9966"
-    dial-timeout:
-    retry-timeout:
-    sort-buffer-len-max:
-    sort-buffer-drain-timeout:
+    retry-timeout: 
+    sort-buffer-len-max: 
+    sort-buffer-drain-timeout: 
     tls-hubble-client-cert-file: /var/lib/hubble-relay/tls/client.crt
     tls-hubble-client-key-file: /var/lib/hubble-relay/tls/client.key
     tls-hubble-server-ca-files: /var/lib/hubble-relay/tls/hubble-server-ca.crt
+    
     disable-server-tls: true
 ---
 # Source: cilium/templates/hubble-ui/configmap.yaml
@@ -253,54 +254,70 @@ spec:
       securityContext:
         fsGroup: 65532
       containers:
-      - name: hubble-relay
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-          runAsGroup: 65532
-          runAsNonRoot: true
-          runAsUser: 65532
-        image: registry.sighup.io/fury/cilium/hubble-relay:v1.16.3
-        imagePullPolicy: IfNotPresent
-        command:
-        - hubble-relay
-        args:
-        - serve
-        ports:
-        - name: grpc
-          containerPort: 4245
-        - name: prometheus
-          containerPort: 9966
-          protocol: TCP
-        readinessProbe:
-          grpc:
-            port: 4222
-          timeoutSeconds: 3
-        livenessProbe:
-          grpc:
-            port: 4222
-          timeoutSeconds: 10
-          failureThreshold: 12
-          initialDelaySeconds: 10
-          periodSeconds: 10
-        startupProbe:
-          grpc:
-            port: 4222
-          failureThreshold: 20
-          periodSeconds: 3
-          initialDelaySeconds: 10
-        volumeMounts:
-        - name: config
-          mountPath: /etc/hubble-relay
-          readOnly: true
-        - name: tls
-          mountPath: /var/lib/hubble-relay/tls
-          readOnly: true
-        terminationMessagePolicy: FallbackToLogsOnError
+        - name: hubble-relay
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            runAsGroup: 65532
+            runAsNonRoot: true
+            runAsUser: 65532
+          image: "registry.sighup.io/fury/cilium/hubble-relay:v1.17.2"
+          imagePullPolicy: IfNotPresent
+          command:
+            - hubble-relay
+          args:
+            - serve
+          ports:
+            - name: grpc
+              containerPort: 4245
+            - name: prometheus
+              containerPort: 9966
+              protocol: TCP
+          readinessProbe:
+            grpc:
+              port: 4222
+            timeoutSeconds: 3
+          # livenessProbe will kill the pod, we should be very conservative
+          # here on failures since killing the pod should be a last resort, and
+          # we should provide enough time for relay to retry before killing it.
+          livenessProbe:
+            grpc:
+              port: 4222
+            timeoutSeconds: 10
+            # Give relay time to establish connections and make a few retries
+            # before starting livenessProbes.
+            initialDelaySeconds: 10
+            # 10 second * 12 failures = 2 minutes of failure.
+            # If relay cannot become healthy after 2 minutes, then killing it
+            # might resolve whatever issue is occurring.
+            #
+            # 10 seconds is a reasonable retry period so we can see if it's
+            # failing regularly or only sporadically.
+            periodSeconds: 10
+            failureThreshold: 12
+          startupProbe:
+            grpc:
+              port: 4222
+            # Give relay time to get it's certs and establish connections and
+            # make a few retries before starting startupProbes.
+            initialDelaySeconds: 10
+            # 20 * 3 seconds = 1 minute of failure before we consider startup as failed.
+            failureThreshold: 20
+            # Retry more frequently at startup so that it can be considered started more quickly.
+            periodSeconds: 3
+          volumeMounts:
+          - name: config
+            mountPath: /etc/hubble-relay
+            readOnly: true
+          - name: tls
+            mountPath: /var/lib/hubble-relay/tls
+            readOnly: true
+          terminationMessagePolicy: FallbackToLogsOnError
+        
       restartPolicy: Always
-      serviceAccount: hubble-relay
-      serviceAccountName: hubble-relay
+      priorityClassName: 
+      serviceAccountName: "hubble-relay"
       automountServiceAccountToken: false
       terminationGracePeriodSeconds: 1
       affinity:
@@ -321,17 +338,18 @@ spec:
             path: config.yaml
       - name: tls
         projected:
-          defaultMode: 256
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
           sources:
           - secret:
               name: hubble-relay-client-certs
               items:
-              - key: tls.crt
-                path: client.crt
-              - key: tls.key
-                path: client.key
-              - key: ca.crt
-                path: hubble-server-ca.crt
+                - key: tls.crt
+                  path: client.crt
+                - key: tls.key
+                  path: client.key
+                - key: ca.crt
+                  path: hubble-server-ca.crt
 ---
 # Source: cilium/templates/hubble-ui/deployment.yaml
 kind: Deployment
@@ -359,12 +377,16 @@ spec:
         app.kubernetes.io/name: hubble-ui
         app.kubernetes.io/part-of: cilium
     spec:
-      serviceAccount: hubble-ui
-      serviceAccountName: hubble-ui
+      securityContext:
+        fsGroup: 1001
+        runAsGroup: 1001
+        runAsUser: 1001
+      priorityClassName: 
+      serviceAccountName: "hubble-ui"
       automountServiceAccountToken: true
       containers:
       - name: frontend
-        image: registry.sighup.io/fury/cilium/hubble-ui:v0.13.1
+        image: "registry.sighup.io/fury/cilium/hubble-ui:v0.13.2"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -385,23 +407,19 @@ spec:
           mountPath: /tmp
         terminationMessagePolicy: FallbackToLogsOnError
       - name: backend
-        image: registry.sighup.io/fury/cilium/hubble-ui-backend:v0.13.1
+        image: "registry.sighup.io/fury/cilium/hubble-ui-backend:v0.13.2"
         imagePullPolicy: IfNotPresent
         env:
         - name: EVENTS_SERVER_PORT
           value: "8090"
         - name: FLOWS_API_ADDR
-          value: hubble-relay:80
+          value: "hubble-relay:80"
         ports:
         - name: grpc
           containerPort: 8090
         terminationMessagePolicy: FallbackToLogsOnError
       nodeSelector:
         kubernetes.io/os: linux
-      securityContext:
-        fsGroup: 1001
-        runAsGroup: 1001
-        runAsUser: 1001
       volumes:
       - configMap:
           defaultMode: 420
@@ -488,12 +506,12 @@ spec:
     - kube-system
   endpoints:
   - port: hubble-metrics
-    interval: 10s
+    interval: "10s"
     honorLabels: true
     path: /metrics
+    scheme: http
     relabelings:
     - replacement: ${1}
       sourceLabels:
       - __meta_kubernetes_pod_node_name
       targetLabel: node
-    scheme: http

--- a/katalog/cilium/hubble/kustomization.yaml
+++ b/katalog/cilium/hubble/kustomization.yaml
@@ -5,8 +5,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: kube-system
-
 resources:
   - ../core
   - deploy.yaml

--- a/katalog/cilium/kustomization.yaml
+++ b/katalog/cilium/kustomization.yaml
@@ -5,7 +5,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: kube-system
-
 resources:
   - hubble

--- a/katalog/tests/calico/resources/echo-server.yaml
+++ b/katalog/tests/calico/resources/echo-server.yaml
@@ -18,7 +18,7 @@ spec:
         app: echoserver
     spec:
       containers:
-      - image: registry.sighup.io/fury/google_containers/echoserver:1.0
+      - image: registry.sighup.io/fury/google_containers/echoserver:1.10
         imagePullPolicy: Always
         name: echoserver
         ports:

--- a/katalog/tigera/MAINTENANCE.md
+++ b/katalog/tigera/MAINTENANCE.md
@@ -11,7 +11,7 @@ To update the YAML file, run the following command:
 
 ```bash
 # assuming katalog/tigera is the root of the repository
-export CALICO_VERSION="3.29.0"
+export CALICO_VERSION="3.29.2"
 curl "https://raw.githubusercontent.com/projectcalico/calico/v${CALICO_VERSION}/manifests/tigera-operator.yaml" --output operator/tigera-operator.yaml
 ```
 
@@ -28,7 +28,7 @@ To download the default configuration from upstream and update the file use the 
 
 ```bash
 # assuming katalog/tigera is the root of the repository
-export CALICO_VERSION="3.29.0"
+export CALICO_VERSION="3.29.2"
 curl https://raw.githubusercontent.com/projectcalico/calico/v${CALICO_VERSION}/manifests/custom-resources.yaml --output on-prem/custom-resources.yaml
 ```
 
@@ -50,7 +50,7 @@ To get the dashboards you can use the following commands:
 
 ```bash
 # ⚠️ Assuming $PWD == root of the project
-export CALICO_VERSION="3.29.0"
+export CALICO_VERSION="3.29.2"
 # we split the upstream file and store only the json files
 curl -L https://raw.githubusercontent.com/projectcalico/calico/v${CALICO_VERSION}/manifests/grafana-dashboards.yaml | yq '.data["felix-dashboard.json"]' | sed 's/calico-demo-prometheus/prometheus/g' | jq > ./on-prem/monitoring/dashboards/felix-dashboard.json
 curl -L https://raw.githubusercontent.com/projectcalico/calico/v${CALICO_VERSION}/manifests/grafana-dashboards.yaml | yq '.data["typha-dashboard.json"]' | sed 's/calico-demo-prometheus/prometheus/g' | jq > ./on-prem/monitoring/dashboards/typa-dashboard.json

--- a/katalog/tigera/on-prem/kustomization.yaml
+++ b/katalog/tigera/on-prem/kustomization.yaml
@@ -10,5 +10,5 @@ resources:
   - custom-resources.yaml
   - monitoring
 
-patchesStrategicMerge:
-  - monitoring/metrics.yaml
+patches:
+  - path: monitoring/metrics.yaml

--- a/katalog/tigera/operator/dummy-dictionary-calico-images.yaml
+++ b/katalog/tigera/operator/dummy-dictionary-calico-images.yaml
@@ -22,19 +22,19 @@ spec:
     spec:
       containers:
         - name: image1
-          image: registry.sighup.io/fury/calico/kube-controllers:v3.29.0
+          image: registry.sighup.io/fury/calico/kube-controllers:v3.29.2
         - name: image2
-          image: registry.sighup.io/fury/calico/cni:v3.29.0
+          image: registry.sighup.io/fury/calico/cni:v3.29.2
         - name: image3
-          image: registry.sighup.io/fury/calico/pod2daemon-flexvol:v3.29.0
+          image: registry.sighup.io/fury/calico/pod2daemon-flexvol:v3.29.2
         - name: image4
-          image: registry.sighup.io/fury/calico/node:v3.29.0
+          image: registry.sighup.io/fury/calico/node:v3.29.2
         - name: image5
-          image: registry.sighup.io/fury/calico/apiserver:v3.29.0
+          image: registry.sighup.io/fury/calico/apiserver:v3.29.2
         - name: image6
-          image: registry.sighup.io/fury/calico/typha:v3.29.0
+          image: registry.sighup.io/fury/calico/typha:v3.29.2
         - name: image7
-          image: registry.sighup.io/fury/calico/csi:v3.29.0
+          image: registry.sighup.io/fury/calico/csi:v3.29.2
         - name: image8
-          image: registry.sighup.io/fury/calico/node-driver-registrar:v3.29.0
+          image: registry.sighup.io/fury/calico/node-driver-registrar:v3.29.2
           

--- a/katalog/tigera/operator/tigera-operator.yaml
+++ b/katalog/tigera/operator/tigera-operator.yaml
@@ -112,8 +112,14 @@ spec:
                           a valid secret key.
                         type: string
                       name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        default: ""
+                        description: 'Name of the referent. This field is effectively
+                          required, but due to backwards compatibility is allowed
+                          to be empty. Instances of this type with an empty value
+                          here are almost certainly wrong. TODO: Add other useful
+                          fields. apiVersion, kind, uid? More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Drop `kubebuilder:default` when controller-gen doesn''t
+                          need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.'
                         type: string
                       optional:
                         description: Specify whether the Secret or its key must be
@@ -464,8 +470,14 @@ spec:
                           a valid secret key.
                         type: string
                       name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        default: ""
+                        description: 'Name of the referent. This field is effectively
+                          required, but due to backwards compatibility is allowed
+                          to be empty. Instances of this type with an empty value
+                          here are almost certainly wrong. TODO: Add other useful
+                          fields. apiVersion, kind, uid? More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Drop `kubebuilder:default` when controller-gen doesn''t
+                          need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.'
                         type: string
                       optional:
                         description: Specify whether the Secret or its key must be
@@ -1865,6 +1877,10 @@ spec:
                 description: 'WireguardRoutingRulePriority controls the priority value
                   to use for the Wireguard routing rule. [Default: 99]'
                 type: integer
+              wireguardThreadingEnabled:
+                description: 'WireguardThreadingEnabled controls whether Wireguard
+                  has NAPI threading enabled. [Default: false]'
+                type: boolean
               workloadSourceSpoofing:
                 description: WorkloadSourceSpoofing controls whether pods can use
                   the allowedSourcePrefixes annotation to send traffic with a source
@@ -7165,6 +7181,21 @@ spec:
             description: Specification of the desired state for the Calico or Calico
               Enterprise installation.
             properties:
+              azure:
+                description: Azure is used to configure azure provider specific options.
+                properties:
+                  policyMode:
+                    default: Default
+                    description: |-
+                      PolicyMode determines whether the "control-plane" label is applied to namespaces. It offers two options: Default and Manual.
+                      The Default option adds the "control-plane" label to the required namespaces.
+                      The Manual option does not apply the "control-plane" label to any namespace.
+                      Default: Default
+                    enum:
+                    - Default
+                    - Manual
+                    type: string
+                type: object
               calicoKubeControllersDeployment:
                 description: |-
                   CalicoKubeControllersDeployment configures the calico-kube-controllers Deployment. If used in
@@ -14534,6 +14565,22 @@ spec:
                 description: Computed is the final installation including overlaid
                   resources.
                 properties:
+                  azure:
+                    description: Azure is used to configure azure provider specific
+                      options.
+                    properties:
+                      policyMode:
+                        default: Default
+                        description: |-
+                          PolicyMode determines whether the "control-plane" label is applied to namespaces. It offers two options: Default and Manual.
+                          The Default option adds the "control-plane" label to the required namespaces.
+                          The Manual option does not apply the "control-plane" label to any namespace.
+                          Default: Default
+                        enum:
+                        - Default
+                        - Manual
+                        type: string
+                    type: object
                   calicoKubeControllersDeployment:
                     description: |-
                       CalicoKubeControllersDeployment configures the calico-kube-controllers Deployment. If used in
@@ -22583,7 +22630,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: tigera-operator
-          image: quay.io/tigera/operator:v1.36.0
+          image: quay.io/tigera/operator:v1.36.5
           imagePullPolicy: IfNotPresent
           command:
             - operator
@@ -22601,7 +22648,7 @@ spec:
             - name: OPERATOR_NAME
               value: "tigera-operator"
             - name: TIGERA_OPERATOR_INIT_IMAGE_VERSION
-              value: v1.36.0
+              value: v1.36.5
           envFrom:
             - configMapRef:
                 name: kubernetes-services-endpoint


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request.
By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull
request to the best possible team for review.

💡 **TIP**
Remember that you can always open a PR in draft status and fill all the information afterwards.

Opening a PR in draft allows other team members to knwo that you are working on this change, and let's you have a 
place to track your work in progress.

When opening PRs in Draft, don't assign reviewers until the PR is ready for review.  Once you are confortable with the
status of the PR and all the tests and CI is green, you can assign the reviewers to start the review process.
-->

### Summary 💡

This PR updates cilium to the latest patch, and tests cilium against Kubernetes 1.32. Kubernetes 1.32 is marked as a tech preview version in the compatibility matrix

Closes: https://github.com/sighupio/product-management/issues/563

* Update docs
* Updated kustomize projects to use v5-compatible features

> [!NOTE]
> This PR is based on #88. You will see changes introduced by both PRs until 88 gets merged.

### Breaking Changes 💔

There are no breaking changes.

### Tests performed 🧪

- [x] Tested a clean OnPremises installation with Kubernetes 1.32 and Cilium as CNI
- [x] e2e tests are passing
