### PR TITLE
feat(cilium): downgrade to v1.18.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Networking Module provides the following packages:
 
 | Package                    | Version  | Description                                                                                                                                          |
 | -------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [cilium](katalog/cilium)   | `1.19.0` | [Cilium][cilium-page] CNI Plugin. For cluster with `< 200` nodes.                                                                                    |
+| [cilium](katalog/cilium)   | `1.18.1` | [Cilium][cilium-page] CNI Plugin. For cluster with `< 200` nodes.                                                                                    |
 | [tigera](katalog/tigera)   | `1.40.3` | [Tigera Operator][tigera-page], a Kubernetes Operator for Calico, provides pre-configured installations for on-prem and for EKS in policy-only mode. |
 
 > The resources in these packages are going to be deployed in `kube-system` namespace. Except for the operator.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Networking Module provides the following packages:
 
 | Package                    | Version  | Description                                                                                                                                          |
 | -------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [cilium](katalog/cilium)   | `1.18.1` | [Cilium][cilium-page] CNI Plugin. For cluster with `< 200` nodes.                                                                                    |
+| [cilium](katalog/cilium)   | `1.18.7` | [Cilium][cilium-page] CNI Plugin. For cluster with `< 200` nodes.                                                                                    |
 | [tigera](katalog/tigera)   | `1.40.3` | [Tigera Operator][tigera-page], a Kubernetes Operator for Calico, provides pre-configured installations for on-prem and for EKS in policy-only mode. |
 
 > The resources in these packages are going to be deployed in `kube-system` namespace. Except for the operator.

--- a/docs/releases/v3.1.0.md
+++ b/docs/releases/v3.1.0.md
@@ -8,7 +8,7 @@ This release updates the Tigera Operator to version 1.40.3 (Calico v3.31.3), Cil
 
 | Component         | Supported Version                                                                | Previous Version |
 | ----------------- | -------------------------------------------------------------------------------- | ---------------- |
-| `cilium`          | [`TDB`](https://github.com/cilium/cilium/releases/tag/v1.18.7)                   | v1.18.1          |
+| `cilium`          | [`v1.18.7`](https://github.com/cilium/cilium/releases/tag/v1.18.7)                   | v1.18.1          |
 | `tigera-operator` | [`v1.40.3`](https://github.com/tigera/operator/releases/tag/v1.40.3)             | v1.38.6          |
 
 > Please refer the individual release notes to get detailed information on each release.

--- a/docs/releases/v3.1.0.md
+++ b/docs/releases/v3.1.0.md
@@ -2,14 +2,14 @@
 
 Welcome to the latest release of the `Networking` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP by ReeVo.
 
-This release updates the Tigera Operator to version 1.40.3 (Calico v3.31.3), Cilium to v1.19.0 and adds support for Kubernetes 1.34.
+This release updates the Tigera Operator to version 1.40.3 (Calico v3.31.3) and adds support for Kubernetes 1.34. Cilium TBD
 
 ## Component Images 🚢
 
-| Component         | Supported Version                                                    | Previous Version |
-| ----------------- | -------------------------------------------------------------------- | ---------------- |
-| `cilium`          | [`v1.19.0`](https://github.com/cilium/cilium/releases/tag/v1.19.0)   | v1.18.1          |
-| `tigera-operator` | [`v1.40.3`](https://github.com/tigera/operator/releases/tag/v1.40.3) | v1.38.6          |
+| Component         | Supported Version                                                                | Previous Version |
+| ----------------- | -------------------------------------------------------------------------------- | ---------------- |
+| `cilium`          | [`TDB`](https://github.com/cilium/cilium/releases/tag/v1.18.1)                   | TDB              |
+| `tigera-operator` | [`v1.40.3`](https://github.com/tigera/operator/releases/tag/v1.40.3)             | v1.38.6          |
 
 > Please refer the individual release notes to get detailed information on each release.
 
@@ -19,7 +19,7 @@ This release updates the Tigera Operator to version 1.40.3 (Calico v3.31.3), Cil
 
 ## Breaking Changes 💔
 
-- [Cilium v1.19.0](https://github.com/cilium/cilium/releases/tag/v1.19.0) introduces some changes to Network Policies, Cluster Mesh, LoadBalancer IPAM or BGP that may require intervention. These changes do not impact the module's out-of-the-box configuration, but users may have to adjust custom configuration if present.
+TBD
 
 ## Update Guide 🦮
 

--- a/docs/releases/v3.1.0.md
+++ b/docs/releases/v3.1.0.md
@@ -2,13 +2,13 @@
 
 Welcome to the latest release of the `Networking` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP by ReeVo.
 
-This release updates the Tigera Operator to version 1.40.3 (Calico v3.31.3) and adds support for Kubernetes 1.34. Cilium TBD
+This release updates the Tigera Operator to version 1.40.3 (Calico v3.31.3), Cilium to v1.18.7 and adds support for Kubernetes 1.34.
 
 ## Component Images 🚢
 
 | Component         | Supported Version                                                                | Previous Version |
 | ----------------- | -------------------------------------------------------------------------------- | ---------------- |
-| `cilium`          | [`TDB`](https://github.com/cilium/cilium/releases/tag/v1.18.1)                   | TDB              |
+| `cilium`          | [`TDB`](https://github.com/cilium/cilium/releases/tag/v1.18.7)                   | v1.18.1          |
 | `tigera-operator` | [`v1.40.3`](https://github.com/tigera/operator/releases/tag/v1.40.3)             | v1.38.6          |
 
 > Please refer the individual release notes to get detailed information on each release.
@@ -19,7 +19,7 @@ This release updates the Tigera Operator to version 1.40.3 (Calico v3.31.3) and 
 
 ## Breaking Changes 💔
 
-TBD
+None.
 
 ## Update Guide 🦮
 

--- a/katalog/cilium/MAINTENANCE.md
+++ b/katalog/cilium/MAINTENANCE.md
@@ -37,7 +37,7 @@ grep -A 10 "kind: ServiceMonitor" upstream-check.yaml | grep -i hubble
 helm repo add cilium https://helm.cilium.io/
 helm repo update
 helm search repo cilium/cilium
-helm pull cilium/cilium --version 1.19.0 --untar --untardir /tmp
+helm pull cilium/cilium --version 1.18.1 --untar --untardir /tmp
 ```
 
 1.2. Compare the `MAINTENANCE.values.yaml` with the one from the chart `/tmp/cilium/values.yaml` and port the changes that are needed. For example, update the image tags and check that parameters that were in use are still valid.
@@ -64,7 +64,7 @@ helm pull cilium/cilium --version 1.19.0 --untar --untardir /tmp
 > The Helm template at `templates/cilium-operator/_helpers.tpl` line 35 constructs the image as:  
 > `printf "%s-%s%s%s%s" repository cloud suffix tag imageDigest`  
 > 
-> Using `operator-generic` results in: `operator-generic-generic:v1.19.0` which causes ImagePullBackOff!
+> Using `operator-generic` results in: `operator-generic-generic:v1.18.1` which causes ImagePullBackOff!
 
 2.1. Render the manifests from the upstream Chart
 
@@ -84,10 +84,10 @@ helm template cilium /tmp/cilium \
 
 ```bash
 # Compare the full core manifests
-dyff between --ignore-whitespace-changes --ignore-order-changes core/deploy.yaml upstream-without-hubble.yaml
+dyff between --ignore-whitespace-changes --ignore-order-changes upstream-without-hubble.yaml core/deploy.yaml
 
 # CRITICAL: Focus specifically on ConfigMap changes (most important for functionality)
-dyff between --filter="kind=ConfigMap,metadata.name=cilium-config" core/deploy.yaml upstream-without-hubble.yaml
+dyff between --filter="kind=ConfigMap,metadata.name=cilium-config" upstream-without-hubble.yaml core/deploy.yaml
 
 # Check for new or changed configuration parameters
 grep -A 100 "kind: ConfigMap" upstream-without-hubble.yaml | grep -E "^  [a-z]" > upstream-config.txt
@@ -113,21 +113,21 @@ helm template cilium /tmp/cilium \
 kustomize build hubble > local-with-hubble.yaml
 ```
 
-3.3. Compare the output against the file `upstream-with-hubble.yaml` to check the differences and port the changes needed to the `hubble` package modifying the `hubble/deploy.yaml` file accordingly.
+3.3  Compare the output againts the file `upstream-with-hubble.yaml` to check the differences and port the changes needed to the `hubble` package modifying the `hubble/deploy.yaml` file accordingly.
 
 ```bash
 # Compare hubble deployments 
-dyff between --ignore-whitespace-changes --ignore-order-changes local-with-hubble.yaml upstream-with-hubble.yaml
+dyff between --ignore-whitespace-changes --ignore-order-changes upstream-with-hubble.yaml local-with-hubble.yaml
 
 # Verify hubble config merge worked correctly
-dyff between --filter="kind=ConfigMap,metadata.name=cilium-config" local-with-hubble.yaml upstream-with-hubble.yaml
+dyff between --filter="kind=ConfigMap,metadata.name=cilium-config" upstream-with-hubble.yaml local-with-hubble.yaml
 ```
 
 ### Expected differences with upstream in the Hubble package
 
 As of v1.18.1, our customizations are minimal and focused on essential additions:
 
-- **Grafana dashboards** - Not included in upstream Helm chart. We add them via Kustomize in `*/monitoring/`. Taken from https://github.com/cilium/cilium/tree/main/install/kubernetes/cilium/files
+- **Grafana dashboards** - Not included in upstream Helm chart. We add them via Kustomize in `monitoring/`.
 - **Issuer resources** - Upstream provides Certificate resources but expects the `hubble-issuer` to exist. We provide the Issuer and CA certificate in `resources/pki.yaml`.
 - **Hubble configuration** - Additional Hubble settings merged via ConfigMapGenerator in `config/hubble.env`.
 

--- a/katalog/cilium/MAINTENANCE.md
+++ b/katalog/cilium/MAINTENANCE.md
@@ -37,7 +37,7 @@ grep -A 10 "kind: ServiceMonitor" upstream-check.yaml | grep -i hubble
 helm repo add cilium https://helm.cilium.io/
 helm repo update
 helm search repo cilium/cilium
-helm pull cilium/cilium --version 1.18.1 --untar --untardir /tmp
+helm pull cilium/cilium --version 1.18.7 --untar --untardir /tmp
 ```
 
 1.2. Compare the `MAINTENANCE.values.yaml` with the one from the chart `/tmp/cilium/values.yaml` and port the changes that are needed. For example, update the image tags and check that parameters that were in use are still valid.
@@ -64,7 +64,7 @@ helm pull cilium/cilium --version 1.18.1 --untar --untardir /tmp
 > The Helm template at `templates/cilium-operator/_helpers.tpl` line 35 constructs the image as:  
 > `printf "%s-%s%s%s%s" repository cloud suffix tag imageDigest`  
 > 
-> Using `operator-generic` results in: `operator-generic-generic:v1.18.1` which causes ImagePullBackOff!
+> Using `operator-generic` results in: `operator-generic-generic:v1.18.7` which causes ImagePullBackOff!
 
 2.1. Render the manifests from the upstream Chart
 

--- a/katalog/cilium/MAINTENANCE.values.yaml
+++ b/katalog/cilium/MAINTENANCE.values.yaml
@@ -6,38 +6,22 @@
 image:
   override: ~
   repository: "registry.sighup.io/fury/cilium/cilium"
+  tag: "v1.18.1"
   useDigest: false
+
+# -- Affinity for cilium-agent.
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchLabels:
+            k8s-app: cilium
 
 hubble:
   # -- Enable Hubble (true by default).
   enabled: true
 
-  metrics:
-    enabled:
-      - dns
-      - drop
-      - tcp
-      - flow
-      - port-distribution
-      - icmp
-      - httpV2:exemplars=true;labelsContext=source_ip,source_namespace,source_workload,destination_ip,destination_namespace,destination_workload,traffic_direction
-    enableOpenMetrics: true
-    tls:
-      enabled: true
-    serviceMonitor:
-      enabled: true
-      tlsConfig:
-        ca:
-          secret:
-            name: hubble-ca-secret
-            key: ca.crt
-    # TODO: we may want to use the dashboards from the Helm chart instead of keeping them updated manually separetely.
-    dashboards:
-      enabled: false
-      namespace: kube-system
-      label: grafana-sighup-dashboard
-      annotations:
-        grafana-folder: "Networking"
   tls:
     # -- Enable mutual TLS for listenAddress. Setting this value to false is
     # highly discouraged as the Hubble API provides access to potentially
@@ -67,6 +51,21 @@ hubble:
         kind: Issuer
         name: hubble-issuer
 
+  metrics:
+    tls:
+      enabled: true
+    enableOpenMetrics: true
+    serviceMonitor:
+      enabled: true
+    enabled:
+      - dns
+      - drop
+      - tcp
+      - flow
+      - port-distribution
+      - icmp
+      - httpV2:exemplars=true;labelsContext=source_ip,source_namespace,source_workload,destination_ip,destination_namespace,destination_workload,traffic_direction
+
   relay:
     # -- Enable Hubble Relay (requires hubble.enabled=true)
     enabled: true
@@ -78,6 +77,7 @@ hubble:
     image:
       override: ~
       repository: "registry.sighup.io/fury/cilium/hubble-relay"
+      tag: "v1.18.1"
 
       useDigest: false
       pullPolicy: "IfNotPresent"
@@ -156,6 +156,75 @@ hubble:
         ipv6:
           enabled: true
 
+# -- Method to use for identity allocation (`crd` or `kvstore`).
+identityAllocationMode: "crd"
+
+# -- (string) Time to wait before using new identity on endpoint identity change.
+# @default -- `"5s"`
+identityChangeGracePeriod: ""
+
+# -- Install Iptables rules to skip netfilter connection tracking on all pod
+# traffic. This option is only effective when Cilium is running in direct
+# routing and full KPR mode. Moreover, this option cannot be enabled when Cilium
+# is running in a managed Kubernetes environment or in a chained CNI setup.
+installNoConntrackIptablesRules: false
+ipam:
+  mode: "cluster-pool"
+  installUplinkRoutesForDelegatedIPAM: false
+  operator:
+    clusterPoolIPv4PodCIDRList: ["10.0.0.0/8"]
+    clusterPoolIPv4MaskSize: 24
+    clusterPoolIPv6PodCIDRList: ["fd00::/104"]
+    clusterPoolIPv6MaskSize: 120
+
+defaultLBServiceIPAM: lbipam
+nodeIPAM:
+  enabled: false
+# -- Configure the eBPF-based ip-masq-agent
+ipMasqAgent:
+  enabled: false
+# the config of nonMasqueradeCIDRs
+# config:
+#   nonMasqueradeCIDRs: []
+#   masqLinkLocal: false
+#   masqLinkLocalIPv6: false
+
+# iptablesLockTimeout defines the iptables "--wait" option when invoked from Cilium.
+# iptablesLockTimeout: "5s"
+
+ipv4:
+  # -- Enable IPv4 support.
+  enabled: true
+
+ipv6:
+  # -- Enable IPv6 support.
+  enabled: false
+
+# -- Configure Kubernetes specific configuration
+k8s:
+  # -- requireIPv4PodCIDR enables waiting for Kubernetes to provide the PodCIDR
+  # range via the Kubernetes node resource
+  requireIPv4PodCIDR: false
+
+  # -- requireIPv6PodCIDR enables waiting for Kubernetes to provide the PodCIDR
+  # range via the Kubernetes node resource
+  requireIPv6PodCIDR: false
+# -- Enable Layer 7 network policy.
+l7Proxy: true
+
+# -- Enable Local Redirect Policy.
+localRedirectPolicy: false
+
+# To include or exclude matched resources from cilium identity evaluation
+# labels: ""
+
+# logOptions allows you to define logging options. eg:
+# logOptions:
+#   format: json
+
+# -- Enables periodic logging of system load
+logSystemLoad: false
+
 # -- Configure prometheus metrics on the configured port at /metrics
 prometheus:
   metricsService: true
@@ -165,8 +234,36 @@ prometheus:
     # -- Enable service monitors.
     # This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
     enabled: true
+    # -- Labels to add to ServiceMonitor cilium-agent
+    labels: {}
+    # -- Annotations to add to ServiceMonitor cilium-agent
+    annotations: {}
+    # -- Interval for scrape metrics.
+    interval: "10s"
+    # -- Specify the Kubernetes namespace where Prometheus expects to find
+    # service monitors configured.
+    # namespace: ""
+    # -- Relabeling configs for the ServiceMonitor cilium-agent
+    relabelings:
+      - sourceLabels:
+          - __meta_kubernetes_pod_node_name
+        targetLabel: node
+        replacement: ${1}
+    # -- Metrics relabeling configs for the ServiceMonitor cilium-agent
+    metricRelabelings: ~
+  # -- Metrics that should be enabled or disabled from the default metric
+  # list. (+metric_foo to enable metric_foo , -metric_bar to disable
+  # metric_bar).
+  # ref: https://docs.cilium.io/en/stable/operations/metrics/#exported-metrics
+  metrics: ~
 
 operator:
+  # -- Enable the cilium-operator component (required).
+  enabled: true
+
+  # -- Roll out cilium-operator pods automatically when configmap is updated.
+  rollOutPods: false
+
   # -- cilium-operator image.
   image:
     override: ~
@@ -174,8 +271,10 @@ operator:
     # Helm template automatically appends cloud suffix (defaults to "generic")
     # See templates/cilium-operator/_helpers.tpl line 35 for logic:
     # printf "%s-%s%s%s%s" .Values.operator.image.repository $cloud .Values.operator.image.suffix $tag $imageDigest
-    # Result: registry.sighup.io/fury/cilium/operator-generic:v1.19.0
+    # Result: registry.sighup.io/fury/cilium/operator-generic:v1.18.1
     repository: "registry.sighup.io/fury/cilium/operator"
+    tag: "v1.18.1"
+
     useDigest: false
     pullPolicy: "IfNotPresent"
     suffix: ""
@@ -191,13 +290,13 @@ operator:
       # This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
       enabled: true
 
-envoy:
+nodeinit:
+  # -- Enable the node initialization DaemonSet
   enabled: false
 
-# TODO: we may want to use the dashboards from the Helm chart instead of keeping them updated manually separetely.
-dashboards:
+preflight:
+  # -- Enable Cilium pre-flight resources (required for upgrade)
   enabled: false
-  namespace: kube-system
-  label: grafana-sighup-dashboard
-  annotations:
-    grafana-folder: "Networking"
+
+envoy:
+  enabled: false

--- a/katalog/cilium/MAINTENANCE.values.yaml
+++ b/katalog/cilium/MAINTENANCE.values.yaml
@@ -6,7 +6,7 @@
 image:
   override: ~
   repository: "registry.sighup.io/fury/cilium/cilium"
-  tag: "v1.18.1"
+  tag: "v1.18.7"
   useDigest: false
 
 # -- Affinity for cilium-agent.
@@ -77,7 +77,7 @@ hubble:
     image:
       override: ~
       repository: "registry.sighup.io/fury/cilium/hubble-relay"
-      tag: "v1.18.1"
+      tag: "v1.18.7"
 
       useDigest: false
       pullPolicy: "IfNotPresent"
@@ -271,9 +271,9 @@ operator:
     # Helm template automatically appends cloud suffix (defaults to "generic")
     # See templates/cilium-operator/_helpers.tpl line 35 for logic:
     # printf "%s-%s%s%s%s" .Values.operator.image.repository $cloud .Values.operator.image.suffix $tag $imageDigest
-    # Result: registry.sighup.io/fury/cilium/operator-generic:v1.18.1
+    # Result: registry.sighup.io/fury/cilium/operator-generic:v1.18.7
     repository: "registry.sighup.io/fury/cilium/operator"
-    tag: "v1.18.1"
+    tag: "v1.18.7"
 
     useDigest: false
     pullPolicy: "IfNotPresent"

--- a/katalog/cilium/core/deploy.yaml
+++ b/katalog/cilium/core/deploy.yaml
@@ -269,6 +269,7 @@ data:
   proxy-idle-timeout-seconds: "60"
   proxy-max-concurrent-retries: "128"
   http-retry-count: "3"
+  http-stream-idle-timeout: "300"
 
   external-envoy-proxy: "false"
   envoy-base-id: "0"
@@ -861,7 +862,7 @@ spec:
           type: Unconfined
       containers:
       - name: cilium-agent
-        image: "registry.sighup.io/fury/cilium/cilium:v1.18.1"
+        image: "registry.sighup.io/fury/cilium/cilium:v1.18.7"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-agent
@@ -1032,7 +1033,7 @@ spec:
         
       initContainers:
       - name: config
-        image: "registry.sighup.io/fury/cilium/cilium:v1.18.1"
+        image: "registry.sighup.io/fury/cilium/cilium:v1.18.7"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-dbg
@@ -1055,7 +1056,7 @@ spec:
       # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
       # We use nsenter command with host's cgroup and mount namespaces enabled.
       - name: mount-cgroup
-        image: "registry.sighup.io/fury/cilium/cilium:v1.18.1"
+        image: "registry.sighup.io/fury/cilium/cilium:v1.18.7"
         imagePullPolicy: IfNotPresent
         env:
         - name: CGROUP_ROOT
@@ -1092,7 +1093,7 @@ spec:
             drop:
               - ALL
       - name: apply-sysctl-overwrites
-        image: "registry.sighup.io/fury/cilium/cilium:v1.18.1"
+        image: "registry.sighup.io/fury/cilium/cilium:v1.18.7"
         imagePullPolicy: IfNotPresent
         env:
         - name: BIN_PATH
@@ -1130,7 +1131,7 @@ spec:
       # from a privileged container because the mount propagation bidirectional
       # only works from privileged containers.
       - name: mount-bpf-fs
-        image: "registry.sighup.io/fury/cilium/cilium:v1.18.1"
+        image: "registry.sighup.io/fury/cilium/cilium:v1.18.7"
         imagePullPolicy: IfNotPresent
         args:
         - 'mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf'
@@ -1146,7 +1147,7 @@ spec:
           mountPath: /sys/fs/bpf
           mountPropagation: Bidirectional
       - name: clean-cilium-state
-        image: "registry.sighup.io/fury/cilium/cilium:v1.18.1"
+        image: "registry.sighup.io/fury/cilium/cilium:v1.18.7"
         imagePullPolicy: IfNotPresent
         command:
         - /init-container.sh
@@ -1193,7 +1194,7 @@ spec:
           mountPath: /var/run/cilium # wait-for-kube-proxy
       # Install the CNI binaries in an InitContainer so we don't have a writable host mount in the agent
       - name: install-cni-binaries
-        image: "registry.sighup.io/fury/cilium/cilium:v1.18.1"
+        image: "registry.sighup.io/fury/cilium/cilium:v1.18.7"
         imagePullPolicy: IfNotPresent
         command:
           - "/install-plugin.sh"
@@ -1365,7 +1366,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: cilium-operator
-        image: "registry.sighup.io/fury/cilium/operator-generic:v1.18.1"
+        image: "registry.sighup.io/fury/cilium/operator-generic:v1.18.7"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-operator-generic
@@ -1448,7 +1449,9 @@ spec:
           operator: Exists
         - key: node.cilium.io/agent-not-ready
           operator: Exists
-      
+        - key: node.cloudprovider.kubernetes.io/uninitialized
+          operator: Exists
+
       volumes:
         # To read the configuration from the config map
       - name: cilium-config-path
@@ -1463,6 +1466,7 @@ metadata:
   namespace: kube-system
   labels:
     app.kubernetes.io/part-of: cilium
+    app.kubernetes.io/name: cilium-agent
 spec:
   selector:
     matchLabels:

--- a/katalog/cilium/core/deploy.yaml
+++ b/katalog/cilium/core/deploy.yaml
@@ -158,7 +158,7 @@ data:
 
   # Name of the cluster. Only relevant when building a mesh of clusters.
   cluster-name: "default"
-  # Unique ID of the cluster. Must be unique across all connected clusters and
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
   # in the range of 1 and 255. Only relevant when building a mesh of clusters.
   cluster-id: "0"
 
@@ -172,7 +172,6 @@ data:
   tunnel-protocol: "vxlan"
   tunnel-source-port-range: "0-0"
   service-no-backend-response: "reject"
-  policy-deny-response: "none"
 
 
   # Enables L7 proxy for L7 policy enforcement and visibility
@@ -181,7 +180,6 @@ data:
   enable-ipv4-big-tcp: "false"
   enable-ipv6-big-tcp: "false"
   enable-ipv6-masquerade: "true"
-  enable-tunnel-big-tcp: "false"
   enable-tcx: "true"
   datapath-mode: "veth"
   enable-masquerade-to-route-source: "false"
@@ -196,14 +194,15 @@ data:
 
 
   kube-proxy-replacement: "false"
-  enable-no-service-endpoints-routable: "true"
   bpf-lb-sock: "false"
+  enable-node-port: "false"
   nodeport-addresses: ""
   enable-health-check-nodeport: "true"
   enable-health-check-loadbalancer-ip: "false"
   node-port-bind-protection: "true"
   enable-auto-protect-node-port-range: "true"
   bpf-lb-acceleration: "disabled"
+  enable-svc-source-range-check: "true"
   enable-l2-neigh-discovery: "false"
   k8s-require-ipv4-pod-cidr: "false"
   k8s-require-ipv6-pod-cidr: "false"
@@ -234,8 +233,6 @@ data:
   vtep-cidr: ""
   vtep-mask: ""
   vtep-mac: ""
-
-  packetization-layer-pmtud-mode: "blackhole"
   procfs: "/host/proc"
   bpf-root: "/sys/fs/bpf"
   cgroup-root: "/run/cilium/cgroupv2"
@@ -245,7 +242,7 @@ data:
   remove-cilium-node-taints: "true"
   set-cilium-node-taints: "true"
   set-cilium-is-up-condition: "true"
-  unmanaged-pod-watcher-interval: "15s"
+  unmanaged-pod-watcher-interval: "15"
   # default DNS proxy to transparent mode in non-chaining modes
   dnsproxy-enable-transparent-mode: "true"
   dnsproxy-socket-linger-timeout: "10"
@@ -258,7 +255,7 @@ data:
   tofqdns-preallocate-identities:  "true"
   agent-not-ready-taint-key: "node.cilium.io/agent-not-ready"
 
-  mesh-auth-enabled: "false"
+  mesh-auth-enabled: "true"
   mesh-auth-queue-size: "1024"
   mesh-auth-rotated-identities-queue-size: "1024"
   mesh-auth-gc-interval: "5m0s"
@@ -267,30 +264,24 @@ data:
   proxy-xff-num-trusted-hops-egress: "0"
   proxy-connect-timeout: "2"
   proxy-initial-fetch-timeout: "30"
-  proxy-max-active-downstream-connections: "50000"
   proxy-max-requests-per-connection: "0"
   proxy-max-connection-duration-seconds: "0"
   proxy-idle-timeout-seconds: "60"
   proxy-max-concurrent-retries: "128"
-  proxy-use-original-source-address: "true"
-  proxy-cluster-max-connections: "1024"
-  proxy-cluster-max-requests: "1024"
   http-retry-count: "3"
-  http-stream-idle-timeout: "300"
 
   external-envoy-proxy: "false"
   envoy-base-id: "0"
   envoy-access-log-buffer-size: "4096"
   envoy-keep-cap-netbindservice: "false"
   max-connected-clusters: "255"
-  clustermesh-cache-ttl: "0s"
   clustermesh-enable-endpoint-sync: "false"
   clustermesh-enable-mcs-api: "false"
-  clustermesh-mcs-api-install-crds: "true"
-  policy-default-local-cluster: "true"
+  policy-default-local-cluster: "false"
 
   nat-map-stats-entries: "32"
   nat-map-stats-interval: "30s"
+  enable-internal-traffic-policy: "true"
   enable-lb-ipam: "true"
   enable-non-default-deny-policies: "true"
   enable-source-ip-verification: "true"
@@ -349,6 +340,7 @@ rules:
   - cilium.io
   resources:
   - ciliumloadbalancerippools
+  - ciliumbgppeeringpolicies
   - ciliumbgpnodeconfigs
   - ciliumbgpadvertisements
   - ciliumbgppeerconfigs
@@ -588,6 +580,7 @@ rules:
   - update
   resourceNames:
   - ciliumloadbalancerippools.cilium.io
+  - ciliumbgppeeringpolicies.cilium.io
   - ciliumbgpclusterconfigs.cilium.io
   - ciliumbgppeerconfigs.cilium.io
   - ciliumbgpadvertisements.cilium.io
@@ -613,6 +606,7 @@ rules:
   resources:
   - ciliumloadbalancerippools
   - ciliumpodippools
+  - ciliumbgppeeringpolicies
   - ciliumbgpclusterconfigs
   - ciliumbgpnodeconfigoverrides
   - ciliumbgppeerconfigs
@@ -646,12 +640,6 @@ rules:
   - create
   - get
   - update
-- apiGroups:
-  - cilium.io
-  resources:
-  - ciliumendpointslices
-  verbs:
-  - deletecollection
 ---
 # Source: cilium/templates/cilium-agent/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -740,29 +728,6 @@ rules:
   - update
   - patch
 ---
-# Source: cilium/templates/cilium-operator/role.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: cilium-operator-ztunnel
-  namespace: kube-system
-  labels:
-    app.kubernetes.io/part-of: cilium
-rules:
-# ZTunnel DaemonSet management permissions
-# Note: These permissions must always be granted (not conditional on encryption.type)
-# because the controller needs to clean up stale DaemonSets when ztunnel is disabled.
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - watch
----
 # Source: cilium/templates/cilium-agent/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -809,23 +774,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: cilium-operator-tlsinterception-secrets
-subjects:
-- kind: ServiceAccount
-  name: "cilium-operator"
-  namespace: kube-system
----
-# Source: cilium/templates/cilium-operator/rolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: cilium-operator-ztunnel
-  namespace: kube-system
-  labels:
-    app.kubernetes.io/part-of: cilium
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: cilium-operator-ztunnel
 subjects:
 - kind: ServiceAccount
   name: "cilium-operator"
@@ -913,7 +861,7 @@ spec:
           type: Unconfined
       containers:
       - name: cilium-agent
-        image: "registry.sighup.io/fury/cilium/cilium:v1.19.0"
+        image: "registry.sighup.io/fury/cilium/cilium:v1.18.1"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-agent
@@ -923,7 +871,7 @@ spec:
           httpGet:
             host: "127.0.0.1"
             path: /healthz
-            port: health
+            port: 9879
             scheme: HTTP
             httpHeaders:
             - name: "brief"
@@ -936,7 +884,7 @@ spec:
           httpGet:
             host: "127.0.0.1"
             path: /healthz
-            port: health
+            port: 9879
             scheme: HTTP
             httpHeaders:
             - name: "brief"
@@ -951,7 +899,7 @@ spec:
           httpGet:
             host: "127.0.0.1"
             path: /healthz
-            port: health
+            port: 9879
             scheme: HTTP
             httpHeaders:
             - name: "brief"
@@ -1014,9 +962,9 @@ spec:
               command:
               - /cni-uninstall.sh
         ports:
-        - name: health
-          containerPort: 9879
-          hostPort: 9879
+        - name: peer-service
+          containerPort: 4244
+          hostPort: 4244
           protocol: TCP
         - name: prometheus
           containerPort: 9962
@@ -1044,7 +992,6 @@ spec:
               - FOWNER
               - SETGID
               - SETUID
-              - SYSLOG
             drop:
               - ALL
         terminationMessagePolicy: FallbackToLogsOnError
@@ -1085,7 +1032,7 @@ spec:
         
       initContainers:
       - name: config
-        image: "registry.sighup.io/fury/cilium/cilium:v1.19.0"
+        image: "registry.sighup.io/fury/cilium/cilium:v1.18.1"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-dbg
@@ -1105,16 +1052,10 @@ spec:
         - name: tmp
           mountPath: /tmp
         terminationMessagePolicy: FallbackToLogsOnError
-        securityContext:
-          capabilities:
-            add:
-              - NET_ADMIN
-            drop:
-              - ALL
       # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
       # We use nsenter command with host's cgroup and mount namespaces enabled.
       - name: mount-cgroup
-        image: "registry.sighup.io/fury/cilium/cilium:v1.19.0"
+        image: "registry.sighup.io/fury/cilium/cilium:v1.18.1"
         imagePullPolicy: IfNotPresent
         env:
         - name: CGROUP_ROOT
@@ -1151,7 +1092,7 @@ spec:
             drop:
               - ALL
       - name: apply-sysctl-overwrites
-        image: "registry.sighup.io/fury/cilium/cilium:v1.19.0"
+        image: "registry.sighup.io/fury/cilium/cilium:v1.18.1"
         imagePullPolicy: IfNotPresent
         env:
         - name: BIN_PATH
@@ -1189,7 +1130,7 @@ spec:
       # from a privileged container because the mount propagation bidirectional
       # only works from privileged containers.
       - name: mount-bpf-fs
-        image: "registry.sighup.io/fury/cilium/cilium:v1.19.0"
+        image: "registry.sighup.io/fury/cilium/cilium:v1.18.1"
         imagePullPolicy: IfNotPresent
         args:
         - 'mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf'
@@ -1205,7 +1146,7 @@ spec:
           mountPath: /sys/fs/bpf
           mountPropagation: Bidirectional
       - name: clean-cilium-state
-        image: "registry.sighup.io/fury/cilium/cilium:v1.19.0"
+        image: "registry.sighup.io/fury/cilium/cilium:v1.18.1"
         imagePullPolicy: IfNotPresent
         command:
         - /init-container.sh
@@ -1252,14 +1193,11 @@ spec:
           mountPath: /var/run/cilium # wait-for-kube-proxy
       # Install the CNI binaries in an InitContainer so we don't have a writable host mount in the agent
       - name: install-cni-binaries
-        image: "registry.sighup.io/fury/cilium/cilium:v1.19.0"
+        image: "registry.sighup.io/fury/cilium/cilium:v1.18.1"
         imagePullPolicy: IfNotPresent
         command:
           - "/install-plugin.sh"
         resources:
-          limits:
-            cpu: 1
-            memory: 1Gi
           requests:
             cpu: 100m
             memory: 10Mi
@@ -1280,7 +1218,6 @@ spec:
       automountServiceAccountToken: true
       terminationGracePeriodSeconds: 1
       hostNetwork: true
-
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -1428,7 +1365,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: cilium-operator
-        image: "registry.sighup.io/fury/cilium/operator-generic:v1.19.0"
+        image: "registry.sighup.io/fury/cilium/operator-generic:v1.18.1"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-operator-generic
@@ -1453,9 +1390,6 @@ spec:
               name: cilium-config
               optional: true
         ports:
-        - name: health
-          containerPort: 9234
-          hostPort: 9234
         - name: prometheus
           containerPort: 9963
           hostPort: 9963
@@ -1464,7 +1398,7 @@ spec:
           httpGet:
             host: "127.0.0.1"
             path: /healthz
-            port: health
+            port: 9234
             scheme: HTTP
           initialDelaySeconds: 60
           periodSeconds: 10
@@ -1473,7 +1407,7 @@ spec:
           httpGet:
             host: "127.0.0.1"
             path: /healthz
-            port: health
+            port: 9234
             scheme: HTTP
           initialDelaySeconds: 0
           periodSeconds: 5
@@ -1483,7 +1417,6 @@ spec:
         - name: cilium-config-path
           mountPath: /tmp/cilium/config-map
           readOnly: true
-        
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -1513,8 +1446,6 @@ spec:
           operator: Exists
         - key: node.kubernetes.io/not-ready
           operator: Exists
-        - key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: Exists
         - key: node.cilium.io/agent-not-ready
           operator: Exists
       
@@ -1532,7 +1463,6 @@ metadata:
   namespace: kube-system
   labels:
     app.kubernetes.io/part-of: cilium
-    app.kubernetes.io/name: cilium-agent
 spec:
   selector:
     matchLabels:
@@ -1546,8 +1476,7 @@ spec:
     honorLabels: true
     path: /metrics
     relabelings:
-    - action: replace
-      replacement: ${1}
+    - replacement: ${1}
       sourceLabels:
       - __meta_kubernetes_pod_node_name
       targetLabel: node

--- a/katalog/cilium/hubble/deploy.yaml
+++ b/katalog/cilium/hubble/deploy.yaml
@@ -252,7 +252,7 @@ spec:
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
-          image: "registry.sighup.io/fury/cilium/hubble-relay:v1.18.1"
+          image: "registry.sighup.io/fury/cilium/hubble-relay:v1.18.7"
           imagePullPolicy: IfNotPresent
           command:
             - hubble-relay
@@ -499,6 +499,9 @@ kind: ServiceMonitor
 metadata:
   name: hubble-relay
   namespace: kube-system
+  labels:
+    app.kubernetes.io/part-of: cilium
+    app.kubernetes.io/name: hubble-relay
 spec:
   selector:
     matchLabels:
@@ -519,6 +522,7 @@ metadata:
   namespace: kube-system
   labels:
     app.kubernetes.io/part-of: cilium
+    app.kubernetes.io/name: hubble
 spec:
   selector:
     matchLabels:

--- a/katalog/cilium/hubble/deploy.yaml
+++ b/katalog/cilium/hubble/deploy.yaml
@@ -57,27 +57,43 @@ metadata:
   labels:
     app.kubernetes.io/part-of: cilium
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - componentstatuses
-      - endpoints
-      - namespaces
-      - nodes
-      - pods
-      - services
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
-      - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - componentstatuses
+  - endpoints
+  - namespaces
+  - nodes
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cilium.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
 ---
 # Source: cilium/templates/hubble-ui/clusterrolebinding.yaml
 kind: ClusterRoleBinding
@@ -91,9 +107,9 @@ roleRef:
   kind: ClusterRole
   name: hubble-ui
 subjects:
-  - kind: ServiceAccount
-    name: hubble-ui
-    namespace: kube-system
+- kind: ServiceAccount
+  name: hubble-ui
+  namespace: kube-system
 ---
 # Source: cilium/templates/hubble-relay/metrics-service.yaml
 # We use a separate service from hubble-relay which can be exposed externally
@@ -110,10 +126,10 @@ spec:
   selector:
     k8s-app: hubble-relay
   ports:
-    - name: metrics
-      port: 9966
-      protocol: TCP
-      targetPort: prometheus
+  - name: metrics
+    port: 9966
+    protocol: TCP
+    targetPort: prometheus
 ---
 # Source: cilium/templates/hubble-relay/service.yaml
 kind: Service
@@ -130,9 +146,9 @@ spec:
   selector:
     k8s-app: hubble-relay
   ports:
-    - port: 80
-      protocol: TCP
-      targetPort: grpc
+  - port: 80
+    protocol: TCP
+    targetPort: grpc
 ---
 # Source: cilium/templates/hubble-ui/service.yaml
 kind: Service
@@ -149,9 +165,9 @@ spec:
   selector:
     k8s-app: hubble-ui
   ports:
-    - name: http
-      port: 80
-      targetPort: 8081
+  - name: http
+    port: 80
+    targetPort: 8081
 ---
 # Source: cilium/templates/hubble/metrics-service.yaml
 apiVersion: v1
@@ -159,7 +175,6 @@ kind: Service
 metadata:
   name: hubble-metrics
   namespace: kube-system
-  annotations:
   labels:
     k8s-app: hubble
     app.kubernetes.io/name: hubble
@@ -168,10 +183,10 @@ spec:
   clusterIP: None
   type: ClusterIP
   ports:
-    - name: hubble-metrics
-      port: 9965
-      protocol: TCP
-      targetPort: hubble-metrics
+  - name: hubble-metrics
+    port: 9965
+    protocol: TCP
+    targetPort: hubble-metrics
   selector:
     k8s-app: cilium
 ---
@@ -189,10 +204,10 @@ spec:
   selector:
     k8s-app: cilium
   ports:
-    - name: peer-service
-      port: 443
-      protocol: TCP
-      targetPort: 4244
+  - name: peer-service
+    port: 443
+    protocol: TCP
+    targetPort: 4244
   internalTrafficPolicy: Local
 ---
 # Source: cilium/templates/hubble-relay/deployment.yaml
@@ -216,7 +231,6 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations:
       labels:
         k8s-app: hubble-relay
         app.kubernetes.io/name: hubble-relay
@@ -232,13 +246,13 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-                - ALL
+              - ALL
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
-          image: "registry.sighup.io/fury/cilium/hubble-relay:v1.19.0"
+          image: "registry.sighup.io/fury/cilium/hubble-relay:v1.18.1"
           imagePullPolicy: IfNotPresent
           command:
             - hubble-relay
@@ -283,12 +297,12 @@ spec:
             # Retry more frequently at startup so that it can be considered started more quickly.
             periodSeconds: 3
           volumeMounts:
-            - name: config
-              mountPath: /etc/hubble-relay
-              readOnly: true
-            - name: tls
-              mountPath: /var/lib/hubble-relay/tls
-              readOnly: true
+          - name: config
+            mountPath: /etc/hubble-relay
+            readOnly: true
+          - name: tls
+            mountPath: /var/lib/hubble-relay/tls
+            readOnly: true
           terminationMessagePolicy: FallbackToLogsOnError
 
       restartPolicy: Always
@@ -299,33 +313,33 @@ spec:
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  k8s-app: cilium
-              topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchLabels:
+                k8s-app: cilium
+            topologyKey: kubernetes.io/hostname
       nodeSelector:
         kubernetes.io/os: linux
       volumes:
-        - name: config
-          configMap:
-            name: hubble-relay-config
-            items:
-              - key: config.yaml
-                path: config.yaml
-        - name: tls
-          projected:
-            # note: the leading zero means this number is in octal representation: do not remove it
-            defaultMode: 0400
-            sources:
-              - secret:
-                  name: hubble-relay-client-certs
-                  items:
-                    - key: tls.crt
-                      path: client.crt
-                    - key: tls.key
-                      path: client.key
-                    - key: ca.crt
-                      path: hubble-server-ca.crt
+      - name: config
+        configMap:
+          name: hubble-relay-config
+          items:
+          - key: config.yaml
+            path: config.yaml
+      - name: tls
+        projected:
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
+          sources:
+          - secret:
+              name: hubble-relay-client-certs
+              items:
+                - key: tls.crt
+                  path: client.crt
+                - key: tls.key
+                  path: client.key
+                - key: ca.crt
+                  path: hubble-server-ca.crt
 ---
 # Source: cilium/templates/hubble-ui/deployment.yaml
 kind: Deployment
@@ -348,7 +362,6 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations:
       labels:
         k8s-app: hubble-ui
         app.kubernetes.io/name: hubble-ui
@@ -362,53 +375,50 @@ spec:
       serviceAccountName: "hubble-ui"
       automountServiceAccountToken: true
       containers:
-        - name: frontend
-          image: "registry.sighup.io/fury/cilium/hubble-ui:v0.13.3"
-          imagePullPolicy: IfNotPresent
-          ports:
-            - name: http
-              containerPort: 8081
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: http
-          readinessProbe:
-            httpGet:
-              path: /
-              port: http
-          volumeMounts:
-            - name: hubble-ui-nginx-conf
-              mountPath: /etc/nginx/conf.d/default.conf
-              subPath: nginx.conf
-            - name: tmp-dir
-              mountPath: /tmp
-          terminationMessagePolicy: FallbackToLogsOnError
-          securityContext:
-            allowPrivilegeEscalation: false
-        - name: backend
-          image: "registry.sighup.io/fury/cilium/hubble-ui-backend:v0.13.3"
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: EVENTS_SERVER_PORT
-              value: "8090"
-            - name: FLOWS_API_ADDR
-              value: "hubble-relay:80"
-          ports:
-            - name: grpc
-              containerPort: 8090
-          terminationMessagePolicy: FallbackToLogsOnError
-          securityContext:
-            allowPrivilegeEscalation: false
-          volumeMounts:
+      - name: frontend
+        image: "registry.sighup.io/fury/cilium/hubble-ui:v0.13.3"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: http
+          containerPort: 8081
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8081
+        volumeMounts:
+        - name: hubble-ui-nginx-conf
+          mountPath: /etc/nginx/conf.d/default.conf
+          subPath: nginx.conf
+        - name: tmp-dir
+          mountPath: /tmp
+        terminationMessagePolicy: FallbackToLogsOnError
+        securityContext:
+          allowPrivilegeEscalation: false
+      - name: backend
+        image: "registry.sighup.io/fury/cilium/hubble-ui-backend:v0.13.3"
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: EVENTS_SERVER_PORT
+          value: "8090"
+        - name: FLOWS_API_ADDR
+          value: "hubble-relay:80"
+        ports:
+        - name: grpc
+          containerPort: 8090
+        terminationMessagePolicy: FallbackToLogsOnError
       nodeSelector:
         kubernetes.io/os: linux
       volumes:
-        - configMap:
-            defaultMode: 420
-            name: hubble-ui-nginx
-          name: hubble-ui-nginx-conf
-        - emptyDir: {}
-          name: tmp-dir
+      - configMap:
+          defaultMode: 420
+          name: hubble-ui-nginx
+        name: hubble-ui-nginx-conf
+      - emptyDir: {}
+        name: tmp-dir
 ---
 # Source: cilium/templates/hubble/tls-certmanager/metrics-server-secret.yaml
 apiVersion: cert-manager.io/v1
@@ -446,17 +456,17 @@ spec:
     kind: Issuer
     name: hubble-issuer
   secretName: hubble-relay-client-certs
-  commonName: "*.hubble-relay.cilium.io"
+  commonName: '*.hubble-relay.cilium.io'
   dnsNames:
-    - "*.hubble-relay.cilium.io"
+  - '*.hubble-relay.cilium.io'
   duration: 26280h0m0s
   privateKey:
     rotationPolicy: Always
   isCA: false
   usages:
-    - signing
-    - key encipherment
-    - client auth
+  - signing
+  - key encipherment
+  - client auth
 ---
 # Source: cilium/templates/hubble/tls-certmanager/server-secret.yaml
 apiVersion: cert-manager.io/v1
@@ -470,9 +480,9 @@ spec:
     kind: Issuer
     name: hubble-issuer
   secretName: hubble-server-certs
-  commonName: "*.default.hubble-grpc.cilium.io"
+  commonName: '*.default.hubble-grpc.cilium.io'
   dnsNames:
-    - "*.default.hubble-grpc.cilium.io"
+  - '*.default.hubble-grpc.cilium.io'
   duration: 26280h0m0s
   privateKey:
     rotationPolicy: Always
@@ -489,20 +499,17 @@ kind: ServiceMonitor
 metadata:
   name: hubble-relay
   namespace: kube-system
-  labels:
-    app.kubernetes.io/part-of: cilium
-    app.kubernetes.io/name: hubble-relay
 spec:
   selector:
     matchLabels:
       k8s-app: hubble-relay
   namespaceSelector:
     matchNames:
-      - kube-system
+    - kube-system
   endpoints:
-    - port: metrics
-      interval: 10s
-      path: /metrics
+  - port: metrics
+    interval: 10s
+    path: /metrics
 ---
 # Source: cilium/templates/hubble/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
@@ -512,25 +519,24 @@ metadata:
   namespace: kube-system
   labels:
     app.kubernetes.io/part-of: cilium
-    app.kubernetes.io/name: hubble
 spec:
   selector:
     matchLabels:
       k8s-app: hubble
   namespaceSelector:
     matchNames:
-      - kube-system
+    - kube-system
   endpoints:
-    - port: hubble-metrics
-      interval: "10s"
-      honorLabels: true
-      path: /metrics
-      tlsConfig:
-        serverName: default.hubble-metrics.cilium.io
-      scheme: https
-      relabelings:
-        - action: replace
-          replacement: ${1}
-          sourceLabels:
-            - __meta_kubernetes_pod_node_name
-          targetLabel: node
+  - port: hubble-metrics
+    interval: "10s"
+    honorLabels: true
+    path: /metrics
+    tlsConfig:
+      serverName: default.hubble-metrics.cilium.io
+    scheme: https
+    relabelings:
+    - action: replace
+      replacement: ${1}
+      sourceLabels:
+      - __meta_kubernetes_pod_node_name
+      targetLabel: node

--- a/katalog/cilium/hubble/kustomization.yaml
+++ b/katalog/cilium/hubble/kustomization.yaml
@@ -19,7 +19,9 @@ configMapGenerator:
       - config/hubble.env
 
 patches:
-  - path: patches/cilium-agent.yaml
+  - path: patches/cilium.yaml
+  # We patch the ServiceMonitor to add the CA for TLS metrics scraping, otherwise
+  # Prometheus will fail to scrape the metrics endpoint.
   - target:
       kind: ServiceMonitor
       name: hubble

--- a/katalog/cilium/hubble/patches/cilium.yaml
+++ b/katalog/cilium/hubble/patches/cilium.yaml
@@ -19,10 +19,6 @@ spec:
               containerPort: 9965
               hostPort: 9965
               protocol: TCP
-            - name: peer-service
-              containerPort: 4244
-              hostPort: 4244
-              protocol: TCP
           volumeMounts:
             - name: hubble-metrics-tls
               mountPath: /var/lib/cilium/tls/hubble-metrics

--- a/katalog/cilium/tasks/preflight.yaml
+++ b/katalog/cilium/tasks/preflight.yaml
@@ -1,0 +1,325 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+---
+# Source: cilium/templates/cilium-preflight/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "cilium-pre-flight"
+  namespace: kube-system
+---
+# Source: cilium/templates/cilium-preflight/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cilium-pre-flight
+  labels:
+    app.kubernetes.io/part-of: cilium
+rules:
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - pods
+  - endpoints
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch
+  # This is used when validating policies in preflight. This will need to stay
+  # until we figure out how to avoid "get" inside the preflight, and then
+  # should be removed ideally.
+  - get
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumloadbalancerippools
+  - ciliumbgppeeringpolicies
+  - ciliumbgpnodeconfigs
+  - ciliumbgpadvertisements
+  - ciliumbgppeerconfigs
+  - ciliumclusterwideenvoyconfigs
+  - ciliumclusterwidenetworkpolicies
+  - ciliumegressgatewaypolicies
+  - ciliumendpoints
+  - ciliumendpointslices
+  - ciliumenvoyconfigs
+  - ciliumidentities
+  - ciliumlocalredirectpolicies
+  - ciliumnetworkpolicies
+  - ciliumnodes
+  - ciliumnodeconfigs
+  - ciliumcidrgroups
+  - ciliuml2announcementpolicies
+  - ciliumpodippools
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumidentities
+  - ciliumendpoints
+  - ciliumnodes
+  verbs:
+  - create
+- apiGroups:
+  - cilium.io
+  # To synchronize garbage collection of such resources
+  resources:
+  - ciliumidentities
+  verbs:
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumendpoints
+  verbs:
+  - delete
+  - get
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnodes
+  - ciliumnodes/status
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies/status
+  - ciliumclusterwidenetworkpolicies/status
+  - ciliumendpoints/status
+  - ciliumendpoints
+  - ciliuml2announcementpolicies/status
+  - ciliumbgpnodeconfigs/status
+  verbs:
+  - patch
+---
+# Source: cilium/templates/cilium-preflight/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-pre-flight
+  labels:
+    app.kubernetes.io/part-of: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-pre-flight
+subjects:
+- kind: ServiceAccount
+  name: "cilium-pre-flight" 
+  namespace: kube-system
+---
+# Source: cilium/templates/cilium-preflight/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cilium-pre-flight-check
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cilium-pre-flight-check
+      kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: cilium
+        k8s-app: cilium-pre-flight-check
+        app.kubernetes.io/name: cilium-pre-flight-check
+        kubernetes.io/cluster-service: "true"
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                k8s-app: cilium
+            topologyKey: kubernetes.io/hostname
+      initContainers:
+        - name: clean-cilium-state
+          image: "registry.sighup.io/fury/cilium/cilium:v1.18.1"
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/echo"]
+          args:
+          - "hello"
+          terminationMessagePolicy: FallbackToLogsOnError
+      containers:
+        - name: cilium-pre-flight-check
+          image: "registry.sighup.io/fury/cilium/cilium:v1.18.1"
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh"]
+          args:
+          - -c
+          - "touch /tmp/ready; sleep 1h"
+          livenessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/ready
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/ready
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          env:
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: spec.nodeName
+          volumeMounts:
+          - name: cilium-run
+            mountPath: /var/run/cilium
+          terminationMessagePolicy: FallbackToLogsOnError
+      hostNetwork: true
+      # This is here to seamlessly allow migrate-identity to work with
+      # etcd-operator setups. The assumption is that other cases would also
+      # work since the cluster DNS would forward the request on.
+      # This differs from the cilium-agent daemonset, where this is only
+      # enabled when etcd.managed=true
+      dnsPolicy: ClusterFirstWithHostNet
+      restartPolicy: Always
+      priorityClassName: system-node-critical
+      serviceAccount: "cilium-pre-flight"
+      serviceAccountName: "cilium-pre-flight"
+      automountServiceAccountToken: true
+      terminationGracePeriodSeconds: 1
+      tolerations:
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+        - key: CriticalAddonsOnly
+          operator: Exists
+      volumes:
+        # To keep state between restarts / upgrades
+      - name: cilium-run
+        hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+      - name: bpf-maps
+        hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+---
+# Source: cilium/templates/cilium-preflight/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cilium-pre-flight-check
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/part-of: cilium
+    app.kubernetes.io/name: cilium-pre-flight-check
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cilium-pre-flight-check-deployment
+      kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: cilium
+        k8s-app: cilium-pre-flight-check-deployment
+        kubernetes.io/cluster-service: "true"
+        app.kubernetes.io/name: cilium-pre-flight-check
+    spec:
+      containers:
+        - name: cnp-validator
+          image: "registry.sighup.io/fury/cilium/cilium:v1.18.1"
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh"]
+          args:
+          - -ec
+          - |
+            cilium-dbg preflight validate-cnp;
+            touch /tmp/ready-validate-cnp;
+            sleep 1h;
+          livenessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/ready-validate-cnp
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/ready-validate-cnp
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          env:
+          terminationMessagePolicy: FallbackToLogsOnError
+      hostNetwork: true
+      restartPolicy: Always
+      priorityClassName: system-cluster-critical
+      serviceAccount: "cilium-pre-flight"
+      serviceAccountName: "cilium-pre-flight"
+      automountServiceAccountToken: true
+      terminationGracePeriodSeconds: 1
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                k8s-app: cilium
+            topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+        - key: CriticalAddonsOnly
+          operator: Exists
+---
+# Source: cilium/templates/cilium-secrets-namespace.yaml
+# Only create the namespace if it's different from Ingress secret namespace or Ingress is not enabled.
+
+# Only create the namespace if it's different from Ingress and Gateway API secret namespaces (if enabled).


### PR DESCRIPTION
### Summary 💡

Downgrade Cilium to v1.18.7 due to [this](https://github.com/cilium/cilium/issues/44464) behaviour.

### Description 📝

See above.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] Tested clean installation on Kubernetes 1.34
- [x] Tested an upgrade from K8s 1.33 to 1.34 from the previous version v1.18.1 with SD on-premises provider

### Future work 🔧

None.
