### PR TITLE
feat: enable whisker observability ui

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,27 @@
+# Networking Core Module Release TBD
+
+Welcome to the latest release of the `Networking` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP by ReeVo.
+
+
+## Component Images 🚢
+
+
+## Bug fixes 🐞
+
+- [[#105]](https://github.com/sighupio/module-networking/pull/105) **Add whisker observability**: enable Calico's Whisker observability UI and its required Goldmane flow aggregator as defaults in the tigera/on-prem package.
+
+## Breaking Changes 💔
+
+
+
+## Update Guide 🦮
+
+### Process
+
+1. Just deploy as usual:
+
+```bash
+kustomize build katalog/tigera/on-prem | kubectl apply -f -
+# OR
+kustomize build katalog/cilium | kubectl apply -f -
+```

--- a/katalog/tigera/on-prem/custom-resources.yaml
+++ b/katalog/tigera/on-prem/custom-resources.yaml
@@ -34,18 +34,16 @@ spec:
 #   name: default
 # spec: {}
 
-# ---
-# By default we don't deploy the Calico Goldmane flow aggregator. If you need it / want it you can deploy it by uncommenting the definition below.
-# # Configures the Calico Goldmane flow aggregator.
-# apiVersion: operator.tigera.io/v1
-# kind: Goldmane
-# metadata:
-#   name: default
+---
+# Configures the Calico Goldmane flow aggregator. Required for Whisker.
+apiVersion: operator.tigera.io/v1
+kind: Goldmane
+metadata:
+  name: default
 
-# ---
-# By default we don't deploy the Calico Whisker observability UI. If you need it / want it you can deploy it by uncommenting the definition below.
-# # Configures the Calico Whisker observability UI.
-# apiVersion: operator.tigera.io/v1
-# kind: Whisker
-# metadata:
-#   name: default
+---
+# Configures the Calico Whisker observability UI.
+apiVersion: operator.tigera.io/v1
+kind: Whisker
+metadata:
+  name: default


### PR DESCRIPTION
### Summary 💡

Enable Calico's Whisker observability UI and its required Goldmane flow aggregator as defaults in the `tigera/on-prem` package, achieving feature parity with the Cilium `hubble` overlay. Neither component is instrumented for Prometheus in this version.

Relates: https://github.com/sighupio/distribution/pull/504

### Description 📝

The Cilium CNI option ships a `hubble` overlay that enables flow visibility (Hubble relay) and a web UI (Hubble UI on port 8081) by default.

Calico (via the Tigera Operator) provides equivalent functionality:

| Feature | Cilium | Tigera |
|---|---|---|
| Flow aggregation | Hubble relay | Goldmane |
| Observability UI | Hubble UI (port 8081) | Whisker (port 8081) |
| Optional Ingress | `hubble-ui` service | `whisker` service |
| Enabled by default | Yes | This PR |

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] Verified Goldmane and Whisker pods are healthy in `calico-system` against a Kind cluster

### Future work 🔧

None.
