### PR TITLE
feat: support calico nftables mode

### DIFF
--- a/katalog/tigera/on-prem/custom-resources.yaml
+++ b/katalog/tigera/on-prem/custom-resources.yaml
@@ -23,6 +23,8 @@ spec:
         # encapsulation: VXLANCrossSubnet
         # natOutgoing: Enabled
         # nodeSelector: all()
+    # Configures LinuxDataplane. Default is "Iptables". Uncomment below when kube-proxy is in nftables mode.
+    # linuxDataplane: "Nftables"
 
 # ---
 # By default we don't deploy the API Server. If you need it / want it you can deploy it by uncommenting the definition below.


### PR DESCRIPTION
### Summary 💡

Document `linuxDataplane: "Nftables"` option in Calico on-prem custom-resources.yaml. Required when kube-proxy runs in nftables mode (K8s >= 1.35).

Relates:
- https://github.com/sighupio/installer-on-premises/pull/167
- https://github.com/sighupio/distribution/pull/505

### Description 📝

Added commented `linuxDataplane: "Nftables"` to the Calico Installation CR template. Calico does not auto-detect the kube-proxy mode so `linuxDataplane` must be set explicitly. This serves as documentation for users; SIGHUP Distribution applies it automatically.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] Verified Calico `NFTablesMode: Enabled` after uncommenting and applying

### Future work 🔧

None.
