### PR TITLE
fix: empty CPU and Memory metrics in Calico Typha Grafana dashboard

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -9,6 +9,7 @@ Welcome to the latest release of the `Networking` module of [`SIGHUP Distributio
 ## Bug fixes 🐞
 
 - [[#105]](https://github.com/sighupio/module-networking/pull/105) **Add whisker observability**: enable Calico's Whisker observability UI and its required Goldmane flow aggregator as defaults in the tigera/on-prem package.
+- [[#107]](https://github.com/sighupio/module-networking/pull/107) **Fix Calico Grafana dashboard**: "CPU Usage" and "Memory Usage" metrics are now populated.
 
 ## Breaking Changes 💔
 

--- a/katalog/tigera/MAINTENANCE.md
+++ b/katalog/tigera/MAINTENANCE.md
@@ -67,6 +67,18 @@ curl -L https://raw.githubusercontent.com/projectcalico/calico/v${CALICO_VERSION
 curl -L https://raw.githubusercontent.com/projectcalico/calico/v${CALICO_VERSION}/manifests/grafana-dashboards.yaml | yq '.data["typha-dashboard.json"]' | sed 's/calico-demo-prometheus/prometheus/g' | jq > ./on-prem/monitoring/dashboards/typa-dashboard.json
 ```
 
+##### ServiceMonitor job label
+
+The upstream Typha dashboard queries metrics with `job="typha_metrics"`. The ServiceMonitor in `monitoring/sm.yaml` uses `jobLabel: k8s-app` which produces `job="calico-typha"`. A relabeling override is applied to fix this:
+
+```yaml
+relabelings:
+  - targetLabel: job
+    replacement: typha_metrics
+```
+
+When updating, verify the relabeling is still present on the calico-typha ServiceMonitor.
+
 #### Alerts
 
 Calico / Tigera upstream does not provide a set of Prometheus Rules that we could include, from [their monitoring documentation](https://projectcalico.docs.tigera.io/maintenance/monitor/monitor-component-metrics) here are the available metrics:

--- a/katalog/tigera/on-prem/monitoring/sm.yaml
+++ b/katalog/tigera/on-prem/monitoring/sm.yaml
@@ -87,6 +87,9 @@ spec:
     - interval: 15s
       # targetPort: 9093
       port: metrics
+      relabelings:
+        - targetLabel: job
+          replacement: typha_metrics
   jobLabel: k8s-app
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
### Summary 💡

Fix empty "CPU Usage" and "Memory Usage" metrics from Calico Typha Grafana dashboard.


### Description 📝

The upstream Calico Typha Grafana dashboard queries metrics with `job="typha_metrics"`, but the ServiceMonitor used `jobLabel: k8s-app` which produces `job="calico-typha"`, causing CPU Usage and Memory Usage panels to show no data.

Adding a relabeling that overrides the job label to `typha_metrics` at scrape time fixes the mismatch without changing the `k8s-app` label on any resource (which would break pod selection).

Before:
<img width="789" height="304" alt="image" src="https://github.com/user-attachments/assets/76fd967e-c962-459c-8b02-f875b118700a" />


After:
<img width="789" height="304" alt="image" src="https://github.com/user-attachments/assets/aa8ecffc-3658-4d89-b805-69331a2a6517" />


### Breaking Changes 💔

Not detected.

### Tests performed 🧪

- Test in local cluster.
- CI: https://ci.sighup.io/sighupio/module-networking/978

### Future work 🔧

Not planned.
