### PR TITLE
feat(ci): test against Kubernets 1.35

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -65,7 +65,7 @@ steps:
       - Render Manifests
     commands:
       # we use --ignore-deprecations because we don't want the CI to fail when the API has not been removed yet.
-      - /pluto detect $${KUBERNETES_MANIFESTS} --ignore-deprecations --target-versions=k8s=v1.33.0
+      - /pluto detect $${KUBERNETES_MANIFESTS} --ignore-deprecations --target-versions=k8s=v1.35.0
     environment:
       KUBERNETES_MANIFESTS: cilium.yml
 
@@ -619,6 +619,188 @@ steps:
       - mise use kind@$${KIND_VERSION}
       - eval "$(mise activate bash --shims)"
       - ./scripts/cleanup-e2e-cluster.sh || true
+
+---
+name: E2E Tests Cilium K8s 1.35
+kind: pipeline
+type: docker
+platform:
+  os: linux
+  arch: amd64
+depends_on:
+  - Linting
+clone:
+  depth: 1
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+
+environment:
+  # Mise configuration
+  MISE_DATA_DIR: "/mise-data"
+  KIND_VERSION: "0.31.0"
+  KUBECTL_VERSION: "1.35.5"
+  BATS_VERSION: "1.11.0"
+  CLUSTER_VERSION: "1.35.0"
+
+volumes:
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
+  - name: mise-cache
+    host:
+      path: /root/mise_data_dir
+steps:
+  - name: Create Kind Cluster
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    network_mode: host
+    environment:
+      GITHUB_TOKEN:
+        from_secret: github_token
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+      - name: mise-cache
+        path: /mise-data
+    depends_on:
+      - clone
+    commands:
+      - mise use kind@$${KIND_VERSION} kubectl@$${KUBECTL_VERSION} kustomize@5.6.0
+      - eval "$(mise activate bash --shims)"
+      - ./scripts/create-e2e-cluster.sh cilium $${CLUSTER_VERSION}
+
+  - name: Run E2E Tests
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    network_mode: host
+    environment:
+      GITHUB_TOKEN:
+        from_secret: github_token
+    volumes:
+      - name: mise-cache
+        path: /mise-data
+    depends_on:
+      - Create Kind Cluster
+    commands:
+      - mise use bats@$${BATS_VERSION} kubectl@$${KUBECTL_VERSION} kustomize@5.6.0
+      - eval "$(mise activate bash --shims)"
+      - ./scripts/run-cilium-tests.sh
+
+  - name: Delete Kind Cluster
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    network_mode: host
+    environment:
+      GITHUB_TOKEN:
+        from_secret: github_token
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+      - name: mise-cache
+        path: /mise-data
+    depends_on:
+      - Run E2E Tests
+    when:
+      status:
+        - success
+        - failure
+    commands:
+      - mise use kind@$${KIND_VERSION}
+      - eval "$(mise activate bash --shims)"
+      - ./scripts/cleanup-e2e-cluster.sh || true
+
+---
+name: E2E Tests Tigera K8s 1.35
+kind: pipeline
+type: docker
+platform:
+  os: linux
+  arch: amd64
+depends_on:
+  - Linting
+clone:
+  depth: 1
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+
+environment:
+  # Mise configuration
+  MISE_DATA_DIR: "/mise-data"
+  KIND_VERSION: "0.31.0"
+  KUBECTL_VERSION: "1.35.5"
+  BATS_VERSION: "1.11.0"
+  CLUSTER_VERSION: "1.35.0"
+
+volumes:
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
+  - name: mise-cache
+    host:
+      path: /root/mise_data_dir
+steps:
+  - name: Create Kind Cluster
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    network_mode: host
+    environment:
+      GITHUB_TOKEN:
+        from_secret: github_token
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+      - name: mise-cache
+        path: /mise-data
+    depends_on:
+      - clone
+    commands:
+      - mise use kind@$${KIND_VERSION} kubectl@$${KUBECTL_VERSION} kustomize@5.6.0
+      - eval "$(mise activate bash --shims)"
+      - ./scripts/create-e2e-cluster.sh tigera $${CLUSTER_VERSION}
+
+  - name: Run E2E Tests
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    network_mode: host
+    environment:
+      GITHUB_TOKEN:
+        from_secret: github_token
+    volumes:
+      - name: mise-cache
+        path: /mise-data
+    depends_on:
+      - Create Kind Cluster
+    commands:
+      - mise use bats@$${BATS_VERSION} kubectl@$${KUBECTL_VERSION} kustomize@5.6.0
+      - eval "$(mise activate bash --shims)"
+      - ./scripts/run-tigera-tests.sh
+
+  - name: Delete Kind Cluster
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    network_mode: host
+    environment:
+      GITHUB_TOKEN:
+        from_secret: github_token
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+      - name: mise-cache
+        path: /mise-data
+    depends_on:
+      - Run E2E Tests
+    when:
+      status:
+        - success
+        - failure
+    commands:
+      - mise use kind@$${KIND_VERSION}
+      - eval "$(mise activate bash --shims)"
+      - ./scripts/cleanup-e2e-cluster.sh || true
 ---
 name: release
 kind: pipeline
@@ -631,9 +813,11 @@ depends_on:
   - E2E Tests Cilium K8s 1.32
   - E2E Tests Cilium K8s 1.33
   - E2E Tests Cilium K8s 1.34
+  - E2E Tests Cilium K8s 1.35
   - E2E Tests Tigera K8s 1.32
   - E2E Tests Tigera K8s 1.33
   - E2E Tests Tigera K8s 1.34
+  - E2E Tests Tigera K8s 1.35
 platform:
   os: linux
   arch: amd64

--- a/mise.toml
+++ b/mise.toml
@@ -4,7 +4,7 @@
 
 [tools]
 kind = "0.31.0"    
-kubectl = "1.34.2"  # Latest stable for local development
+kubectl = "1.35.5"  # Latest stable for local development
 kustomize = "5.6.0"
 helm = "3.15.0"    
 yq = "4.43.1"      
@@ -12,7 +12,7 @@ go = "1.23"
 bats = "1.11.0"    
 dyff = "1.9.0"    
 drone = "1.9.0"
-kapp = "0.64.2"     # For GitOps-style deployments
+kapp = "0.65.0"     # For GitOps-style deployments
 "ubi:google/addlicense" = "v1.1.1"     
 stern = "1.33.0"
 
@@ -45,24 +45,24 @@ echo "✅ Development environment ready!"
 '''
 
 [tasks.e2e-tigera]
-description = "Run Tigera E2E test suite with Kind cluster (K8s 1.34)"
+description = "Run Tigera E2E test suite with Kind cluster (K8s 1.35)"
 run = '''
 #!/bin/bash
 set -e
 echo "🚀 Running Tigera E2E workflow..."
-./scripts/create-e2e-cluster.sh tigera 1.34.0
+./scripts/create-e2e-cluster.sh tigera 1.35.0
 ./scripts/run-tigera-tests.sh
 ./scripts/cleanup-e2e-cluster.sh tigera
 echo "✅ Tigera E2E workflow completed!"
 '''
 
 [tasks.e2e-cilium]
-description = "Run Cilium E2E test suite with Kind cluster (K8s 1.34)"
+description = "Run Cilium E2E test suite with Kind cluster (K8s 1.35)"
 run = '''
 #!/bin/bash
 set -e
 echo "🚀 Running Cilium E2E workflow..."
-./scripts/create-e2e-cluster.sh cilium 1.34.0
+./scripts/create-e2e-cluster.sh cilium 1.35.0
 ./scripts/run-cilium-tests.sh
 ./scripts/cleanup-e2e-cluster.sh cilium
 echo "✅ Cilium E2E workflow completed!"
@@ -71,11 +71,11 @@ echo "✅ Cilium E2E workflow completed!"
 # Individual E2E workflow components (following module-auth pattern)
 [tasks.e2e-create-cluster-tigera]
 description = "Create Kind cluster for Tigera E2E testing"
-run = "./scripts/create-e2e-cluster.sh tigera 1.34.0"
+run = "./scripts/create-e2e-cluster.sh tigera 1.35.0"
 
 [tasks.e2e-create-cluster-cilium]
 description = "Create Kind cluster for Cilium E2E testing"
-run = "./scripts/create-e2e-cluster.sh cilium 1.34.0"
+run = "./scripts/create-e2e-cluster.sh cilium 1.35.0"
 
 [tasks.e2e-run-tests-tigera]
 description = "Run Tigera E2E tests on existing cluster"


### PR DESCRIPTION
### Summary 💡

Add CI steps for testing the module against Kubernetes 1.35

### Description 📝

See summary

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] CI is passing
- [x] local e2e are passing (`mise run e2e-*`)

### Future work 🔧

I may remove the test for 1.32 depending on what comes out from upgrading the packages in following PRs.