### PR TITLE
docs: refactor module documentation, drop legacy Furyfile flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,21 +51,21 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 
 ### Configuration
 
-You configure the module under `spec.distribution.modules.networking` in your `furyctl.yaml`. The `type` field selects the CNI plugin to deploy: `calico` (Tigera Operator) or `cilium` (on `KFDDistribution` you can also set `none` when the CNI is managed outside this module). You must also set the pod CIDR for the selected CNI. The other fields are optional and fall back to sensible defaults.
+You configure the module under `spec.distribution.modules.networking` in your `furyctl.yaml`. The `type` field selects the CNI plugin to deploy: `calico` (Tigera Operator) or `cilium` (on `KFDDistribution` you can also set `none` when the CNI is managed outside this module). The other fields are optional and fall back to sensible defaults.
+
+On an **`OnPremises`** cluster `furyctl` manages the Kubernetes phase too, so the pod CIDR is taken from the cluster's `spec.kubernetes` configuration and the `podCidr`/`maskSize` fields are optional:
 
 ```yaml
 apiVersion: kfd.sighup.io/v1alpha2
-kind: KFDDistribution
+kind: OnPremises
 spec:
   distribution:
     modules:
       networking:
         type: calico
-        tigeraOperator:
-          podCidr: 10.244.0.0/16
 ```
 
-To use Cilium instead of Calico, set `type: cilium` and configure the `cilium` block:
+On a **`KFDDistribution`** cluster (an already existing cluster, with no Kubernetes phase managed by `furyctl`) you set the pod CIDR explicitly when using Cilium:
 
 ```yaml
 apiVersion: kfd.sighup.io/v1alpha2

--- a/README.md
+++ b/README.md
@@ -13,26 +13,24 @@
 ![License](https://img.shields.io/github/license/sighupio/module-networking?label=License)
 ![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)
 
-<!-- <KFD-DOCS> -->
+<!-- <SD-DOCS> -->
 
-**Networking Module** implements in-cluster networking functionality for the [SIGHUP Distribution (SD)][skd-repo] via Container Network Interface (CNI) plugins.
+**Networking Module** implements in-cluster networking for [SIGHUP Distribution (SD)][kfd-repo] via Container Network Interface (CNI) plugins.
 
-If you are new to SD please refer to the [official documentation][skd-docs] on how to get started with SD.
+If you are new to SD please refer to the [official documentation][kfd-docs] on how to get started with SD.
 
 ## Overview
 
-Kubernetes has adopted the Container Network Interface (CNI) specification for managing network resources on a cluster.
-
-**Networking Module** makes use of CNCF Projects [Tigera Calico](https://www.projectcalico.org/) and [Cilium](https://cilium.io/), open-source networking and network security solutions for containers, virtual machines, and bare-metal workloads, to bring networking features to the SIGHUP Distribution.
+Kubernetes adopts the Container Network Interface (CNI) specification for managing network resources on a cluster. **Networking Module** uses the CNCF projects [Calico][tigera-page] (via the Tigera Operator) and [Cilium][cilium-page] — open-source networking and network security solutions for containers, virtual machines and bare-metal workloads — to bring networking capabilities to the distribution.
 
 ## Packages
 
-Networking Module provides the following packages:
+The following packages are included in Networking Module:
 
-| Package                    | Version                     | Description                                                                                                                                          |
-| -------------------------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [cilium](katalog/cilium)   | `1.18.11`                   | [Cilium][cilium-page] CNI Plugin. For cluster with `< 200` nodes.                                                                                    |
-| [tigera](katalog/tigera)   | `1.40.13` (Calico `3.31.6`) | [Tigera Operator][tigera-page], a Kubernetes Operator for Calico, provides pre-configured installations for on-prem and for EKS in policy-only mode. |
+| Package                  | Version                     | Description                                                                                                                                          |
+| ------------------------ | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [cilium](katalog/cilium) | `1.18.11`                   | [Cilium][cilium-page] CNI plugin. For clusters with `< 200` nodes.                                                                                   |
+| [tigera](katalog/tigera) | `1.40.13` (Calico `3.31.6`) | [Tigera Operator][tigera-page], a Kubernetes Operator for Calico, provides pre-configured installations for on-prem and for EKS in policy-only mode. |
 
 Click on each package to see its full documentation.
 
@@ -45,106 +43,73 @@ Click on each package to see its full documentation.
 | `1.34.x`           | :white_check_mark: | No known issues |
 | `1.35.x`           | :white_check_mark: | No known issues |
 
-Check the [compatibility matrix][compatibility-matrix] for additional information on previous releases of the module.
+Check the [compatibility matrix][compatibility-matrix] for additional information about previous releases of the module.
 
 ## Usage
 
-### Prerequisites
+**Networking Module** is part of SIGHUP Distribution (SD) and is deployed automatically by [`furyctl`][furyctl-repo] when you create or update a `KFDDistribution` or `OnPremises` cluster. You don't need to download, vendor or install its packages manually.
 
-| Tool                        | Version   | Description                                                                                                                                                      |
-| --------------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [furyctl][furyctl-repo]     | `>=0.6.0` | The recommended tool to download and manage SD modules and their packages. To learn more about `furyctl` read the [official documentation][furyctl-repo].       |
-| [kustomize][kustomize-repo] | `=3.5.3`  | Packages are customized using `kustomize`. To learn how to create your customization layer with `kustomize`, please refer to their [repository][kustomize-repo]. |
+### Configuration
 
-### Deployment with furyctl legacy
-
-1. List the packages you want to deploy and their version in a `Furyfile.yml`
+You configure the module under `spec.distribution.modules.networking` in your `furyctl.yaml`. The `type` field selects the CNI plugin to deploy: `calico` (Tigera Operator) or `cilium` (on `KFDDistribution` you can also set `none` when the CNI is managed outside this module). You must also set the pod CIDR for the selected CNI. The other fields are optional and fall back to sensible defaults.
 
 ```yaml
-bases:
-  - name: networking
-    version: "v3.1.0"
+apiVersion: kfd.sighup.io/v1alpha2
+kind: KFDDistribution
+spec:
+  distribution:
+    modules:
+      networking:
+        type: calico
+        tigeraOperator:
+          podCidr: 10.244.0.0/16
 ```
 
-> See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
-
-2. Execute `furyctl vendor -H` to download the packages
-
-3. Inspect the download packages under `./vendor/katalog/networking`.
-
-4. Define a `kustomization.yaml` that includes the `./vendor/katalog/networking` directory as a resource.
+To use Cilium instead of Calico, set `type: cilium` and configure the `cilium` block:
 
 ```yaml
-resources:
-  - ./vendor/katalog/networking/tigera/operator
-  - ./vendor/katalog/networking/tigera/on-prem
+apiVersion: kfd.sighup.io/v1alpha2
+kind: KFDDistribution
+spec:
+  distribution:
+    modules:
+      networking:
+        type: cilium
+        cilium:
+          podCidr: 10.0.0.0/8
+          maskSize: "24"
 ```
 
-Or if you want to use Cilium:
+See the configuration reference for your cluster kind for the full list of available options: [KFDDistribution][schema-reference-kfd] or [OnPremises][schema-reference-onprem].
 
-```yaml
-resources:
-  - ./vendor/katalog/networking/cilium
-```
-
-5. To deploy the packages to your cluster, execute:
-
-```bash
-kustomize build . | kubectl apply -f -
-```
-
-### Monitoring
-
-The Networking module includes out-of-the-box metrics monitoring and alerting features for its components.
-
-You can monitor the status of the networking stack from the provided Grafana dashboards:
-
-<!-- markdownlint-disable MD033 -->
-
-<a href="docs/images/screenshots/calico-felix-dashboard.png"><img src="docs/images/screenshots/calico-felix-dashboard.png" width="250"/></a>
-<a href="docs/images/screenshots/calico-typha-dashboard.png"><img src="docs/images/screenshots/calico-typha-dashboard.png" width="250"/></a>
-
-<!-- markdownlint-enable MD033 -->
-
-> click on each screenshot for the full screen version
-
-The following set of alerts is included with the networking module:
-
-| Alert Name                     | Summary                                                                 | Description                                                                                                                       |
-| ------------------------------ | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| CalicoDataplaneFailuresHigh    | A high number of dataplane failures within Felix are happening          | Calico node pod {{ $labels.pod }} ({{ $labels.instance }}) has seen {{ $value }} dataplane failures within the last hour          |
-| CalicoIpsetErrorsHigh          | A high number of ipset errors within Felix are happening                | Calico node pod {{ $labels.pod }} ({{ $labels.instance }}) has seen {{ $value }} ipset errors within the last hour                |
-| CalicoIptableSaveErrorsHigh    | A high number of iptable save errors within Felix are happening         | Calico node pod {{ $labels.pod }} ({{ $labels.instance }}) has seen {{ $value }} iptable save errors within the last hour         |
-| CalicoIptableRestoreErrorsHigh | A high number of iptable restore errors within Felix are happening      | Calico node pod {{ $labels.pod }} ({{ $labels.instance }}) has seen {{ $value }} iptable restore errors within the last hour      |
-| CalicoErrorsWhileLoggingHigh   | A high number of errors within Felix while loggging are happening       | Calico node pod {{ $labels.pod }} ({{ $labels.instance }}) has seen {{ $value }} errors while logging within the last ten minutes |
-| TyphaPingLatency               | Typha Round-trip ping latency to client (cluster {{ $labels.cluster }}) | Typha latency is growing (ping operations > 100ms). VALUE = {{ $value }}. LABELS = {{ $labels }}                                  |
-| TyphaClientWriteLatency        | Typha unusual write latency (instance {{ $labels.cluster }})            | Typha client latency is growing (write operations > 100ms). VALUE = {{ $value }}. LABELS = {{ $labels }}                          |
-| TyphaErrorsWhileLoggingHigh    | A high number of errors within Typha while loggging are happening       | Typha pod {{ $labels.pod }} ({{ $labels.instance }}) has seen {{ $value }} errors while logging within the last ten minutes       |
+To install SD from scratch, follow the [Getting started][getting-started] guide.
 
 <!-- Links -->
 
 [cilium-page]: https://github.com/cilium/cilium
 [tigera-page]: https://github.com/projectcalico/calico
-[skd-repo]: https://github.com/sighupio/distribution
+[kfd-repo]: https://github.com/sighupio/distribution
 [furyctl-repo]: https://github.com/sighupio/furyctl
-[kustomize-repo]: https://github.com/kubernetes-sigs/kustomize
-[skd-docs]: https://docs.kubernetesfury.com/docs/distribution/
-[compatibility-matrix]: https://github.com/sighupio/module-networking/blob/master/docs/COMPATIBILITY_MATRIX.md
+[kfd-docs]: https://docs.sighup.io/docs/distribution/
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulesnetworking
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulesnetworking
+[getting-started]: https://docs.sighup.io/docs/getting-started/
+[compatibility-matrix]: https://github.com/sighupio/module-networking/blob/main/docs/COMPATIBILITY_MATRIX.md
 
-<!-- </KFD-DOCS> -->
+<!-- </SD-DOCS> -->
 
 <!-- <FOOTER> -->
 
 ## Contributing
 
-Before contributing, please read first the [Contributing Guidelines](docs/CONTRIBUTING.md).
+Before contributing, please read first the [Contributing Guidelines](https://github.com/sighupio/distribution/blob/main/docs/CONTRIBUTING.md).
 
 ### Reporting Issues
 
-In case you experience any problems with the module, please [open a new issue](https://github.com/sighupio/module-networking/issues/new/choose).
+In case you experience any problem with the module, please [open a new issue](https://github.com/sighupio/module-networking/issues/new/choose).
 
 ## License
 
-This module is open-source and it's released under the following [LICENSE](LICENSE)
+This module is open-source and it's released under the following [LICENSE](LICENSE).
 
 <!-- </FOOTER> -->

--- a/katalog/cilium/README.md
+++ b/katalog/cilium/README.md
@@ -1,107 +1,35 @@
 # Cilium
 
-<!-- <KFD-DOCS> -->
+<!-- <SD-DOCS> -->
 
-**Cilium** is an open source, cloud native solution for providing, securing, and observing network connectivity between
-workloads, fueled by the revolutionary Kernel technology eBPF.
+## Overview
 
-> For more information about Cilium refer to [cilium documentation][cilium-documentation]
-
-The deployment of Cilium consists of a DaemonSet running on all nodes, and an operator Deployment.
-Additionally, we deploy the Hubble component as an observability tool on the network connections in the cluster.
+Cilium is an open source, cloud native solution for providing, securing and observing network connectivity between workloads, fueled by the eBPF kernel technology. In the Networking Module it is deployed as a DaemonSet running on all nodes plus an operator Deployment, together with the Hubble observability components. Cilium is configured in IPAM Cluster Scope mode.
 
 > [!IMPORTANT]
-> Please notice that the Cilium package default configuration is for cluster with less than 200 nodes.
-
-## Image repository and tag
-
-- cilium images:
-  - `registry.sighup.io/fury/cilium/cilium`
-  - `registry.sighup.io/fury/cilium/operator-generic`
-  - `registry.sighup.io/fury/cilium/hubble-ui-backend`
-  - `registry.sighup.io/fury/cilium/hubble-ui`
-  - `registry.sighup.io/fury/cilium/hubble-relay`
-
-## Requirements
-
-- Kubernetes >= `1.29.X`.
-- Kustomize >= `v5.6.0`.
-- [prometheus-operator from SD Monitoring module][prometheus-operator]
-- [cert-manager from SD Ingress module][cert-manager]
-
-## Configuration
-
-The Cilium package is deployed with the following configuration:
-
-- Cilium configured in IPAM Cluster Scope [The default one](https://docs.cilium.io/en/v1.13/network/concepts/ipam/cluster-pool/)
-- Default pod CIDR: 10.0.0.0/8
-- Default netmask per node: 24
+> The default Cilium configuration targets clusters with less than 200 nodes.
 
 > [!WARNING]
-> Make sure to change the Default pod CIDR if it's conflicting with your network otherwise if your node network is in
-> the same range you will lose connectivity to other nodes.
+> Make sure the pod CIDR does not conflict with your node network: if they overlap you may lose connectivity between nodes.
 
-To change the default pod CIDR you can use the following kustomize patch:
+## Upstream project
 
-`kustomization.yaml`
-
-```yaml
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-namespace: kube-system
-
-configMapGenerator:
-  - name: cilium-config
-    behavior: merge
-    namespace: kube-system
-    envs:
-      - patches/cilium-cidr.env
-```
-
-`patches/cilium-cidr.env`
-
-```dotenv
-cluster-pool-ipv4-cidr=10.100.0.0/8
-cluster-pool-ipv4-mask-size=24
-```
-
-> [!NOTE]
-> The CIDR used by Cilium can be different from the one used by Kubeadm.
-
-## Architecture and Customizations
-
-- Base Cilium CNI installation
-- Cilium operator for managing network policies
-- ServiceMonitors for Prometheus integration
-- Hubble observability components (relay, UI)
-- **Minimal customizations** as of v1.18.1:
-  - **cert-manager Issuer** - Required for TLS certificate generation
+This package is based on the upstream [Cilium][cilium-github].
 
 ## Deployment
 
-You can deploy Cilium by running the following command in the root of this package:
+This package is deployed as part of **Networking Module** when you create a cluster with `furyctl` and `spec.distribution.modules.networking.type` is set to `cilium`.
 
-```bash
-kustomize build . | kubectl apply -f -
-```
+You can customize it (for example the pod CIDR and the per-node mask size) under `spec.distribution.modules.networking.cilium` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
-> [!IMPORTANT]
-> The new single package introduces a cyclic dependency between Cilium and cert-manager. Hubble (deployed together with Cilium) requires cert-manager, and cert-manager requires at least some nodes to be ready (CNI working) to be scheduled.
->
-> You may need to adjust your deployment strategy while switching to the unified package.
->
-> For example, if you are using a tool that verifies dependencies (like Carvel `kapp`) you may apply cert-manager and cilium together in the same `kapp deploy` command.
->
-> If you are using plain `kubectl apply` instead, you will see some messages saying that the resources that require cert-manager (like `Certificate`, `Issuer`, etc.) are not being deployed. You will need to re-apply the cilium package after you've deployed cert-manager so Hubble works.
+<!-- Links -->
 
-<!-- LINKS -->
-[cilium-documentation]: https://docs.cilium.io/en/stable/
-[prometheus-operator]: https://github.com/sighup-io/fury-kubernetes-monitoring/blob/master/katalog/prometheus-operator
-[cert-manager]: https://github.com/sighup-io/fury-kubernetes-ingress/blob/master/katalog/cert-manager
+[cilium-github]: https://github.com/cilium/cilium
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulesnetworking
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulesnetworking
 
-<!-- </KFD-DOCS> -->
+<!-- </SD-DOCS> -->
 
 ## License
 
-For license details please see [LICENSE](./../../LICENSE)
+For license details please see [LICENSE](../../LICENSE)

--- a/katalog/tigera/README.md
+++ b/katalog/tigera/README.md
@@ -1,34 +1,33 @@
-# Tigera Package
+# Tigera
 
-The Tigera package provides the Tigera Operator, a Kubernetes Operator for Calico, and some ready to go configurations to enable Networking capabilities for a Kubernetes cluster.
+<!-- <SD-DOCS> -->
 
-## Tigera Operator
+## Overview
 
-The Tigera Operator handles the installation and life-cycle of the Calico CNI.
+The Tigera package provides the Tigera Operator, a Kubernetes Operator that handles the installation and life-cycle of the [Calico][calico-github] CNI. It ships ready-to-go configurations for two scenarios:
 
-### On-premises installation
+- **On-premises**: the operator deploys and configures Calico as the cluster CNI.
+- **EKS policy-only mode**: the operator runs only to enforce network policies (the CNI features are disabled), leaving the AWS CNI in place.
 
-To install the Tigera operator in an empty on-premises cluster run the following command:
+## Upstream project
 
-1. Deploy the `on-prem` package, it will deploy both the Operator and the configuration needed to set up Calico CNI:
+This package is based on the upstream [Calico][calico-github] and its [Tigera Operator][tigera-github].
 
-```bash
-kustomize build katalog/tigera/on-prem | kubectl apply -f - --server-side
-```
+## Deployment
 
-If you would like to customize the installation, patch the `tigera/on-prem/custom-resources.yaml` your desired configuration. See the [official documentation](https://projectcalico.docs.tigera.io/getting-started/kubernetes/installation/config-options) for details.
+This package is deployed as part of **Networking Module** when you create a cluster with `furyctl` and `spec.distribution.modules.networking.type` is set to `calico`. The right configuration (on-premises CNI or EKS policy-only mode) is selected automatically based on the cluster.
 
-### EKS Policy-only mode installation
+You can customize it (for example the pod CIDR and block size) under `spec.distribution.modules.networking.tigeraOperator` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
-The `eks-policy-mode` package is used to run the Tigera Operator for enforcing network policies -and not as CNI- in a EKS cluster.
+<!-- Links -->
 
-The policy only mode will install the operator and configure it to not enable the CNI features.
+[calico-github]: https://github.com/projectcalico/calico
+[tigera-github]: https://github.com/tigera/operator
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulesnetworking
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulesnetworking
 
-To install it run the following command:
+<!-- </SD-DOCS> -->
 
-```bash
-kustomize build katalog/tigera/policy-only | kubectl apply -f - --server-side
-```
+## License
 
-> Note that you can also completely replace the AWS CNI with Calico if you need to:
-> <https://projectcalico.docs.tigera.io/getting-started/kubernetes/managed-public-cloud/eks>
+For license details please see [LICENSE](../../LICENSE)


### PR DESCRIPTION
### Summary 💡

This PR replicates the documentation refactor defined in `module-aws` (#104) on this module: the docs are now furyctl/SD-centric and the legacy `Furyfile.yml` + `furyctl legacy vendor` + `kustomize build | kubectl apply` workflow has been removed.

Relates: sighupio/module-aws#104

### Description 📝

- **`README.md` (SD-DOCS block)**: removed the legacy `Usage`/`Prerequisites`/deployment sections (Furyfile, kustomize, monitoring screenshots/alerts table). New `Usage` section explains the module is deployed automatically by `furyctl`, with separate `furyctl.yaml` examples for `OnPremises` (pod CIDR taken from the Kubernetes phase, so `podCidr`/`maskSize` are optional) and `KFDDistribution` (pod CIDR set explicitly for Cilium). Renamed `KFD-DOCS` markers to `SD-DOCS`, links to `docs.sighup.io`.
- **Scoped references correctly**: this module does not exist on `EKSCluster` (CNI handled by the AWS module), so the wording and schema-reference links target only `KFDDistribution` and `OnPremises`.
- **`katalog/*/README.md`** (cilium, tigera): rewritten to the shared template; removed kustomize/`kubectl apply` instructions, raw manifests, image coordinates and prerequisites; kept the pod-CIDR conflict warning and the `< 200` nodes note.

### Breaking Changes 💔

None, documentation only.

### Tests performed 🧪

- [x] No `Furyfile` / `furyctl legacy vendor` / `kustomize build | kubectl apply` references left in the `SD-DOCS` blocks
- [x] `furyctl.yaml` snippet fields match the v1alpha2 schema per cluster kind (Cilium `podCidr`/`maskSize` required on KFDDistribution, optional on OnPremises)
- [x] Visual review of the GitHub markdown rendering

### Future work 🔧

- Replicate the same template on the remaining modules.